### PR TITLE
Batch parallel s3 pull, REPLACE_BYTE_CODES to config

### DIFF
--- a/pypdftotext/__init__.py
+++ b/pypdftotext/__init__.py
@@ -22,7 +22,6 @@ def pdf_text_pages(
     pdf_reader: PdfReader | io.BytesIO | bytes,
     debug_path: Path | None = None,
     page_indices: list[int] | None = None,
-    replace_byte_codes: dict[bytes, bytes] | None = None,
     **kwargs,  # prevent errors due to bad args in upstream config dicts
 ) -> list[str]:
     """
@@ -43,11 +42,6 @@ def pdf_text_pages(
             Defaults to None.
         page_indices (list[int] | None): if provided, only extract text from
             the listed page indices. Default is None (extract all pages).
-        replace_byte_codes (dict[bytes, bytes] | None): if supplied, raw
-            text is cast to bytes, the dict keys are replaced with values,
-            and resulting bytes are cast back to text. Used to replace custom
-            glyphs defined in PDFs w/ (roughtly) equivalent unicode charcters,
-            e.g. 'anesthesia billing print set' checkbox handling.
 
     Returns:
         list[str]: a string of text extracted for each page
@@ -65,7 +59,6 @@ def pdf_text_pages(
         pdf_reader,
         config,
         debug_path=debug_path,
-        replace_byte_codes=replace_byte_codes,
         azure=AZURE_READ,
     )
     page_indices = page_indices or list(range(len(pdf_extract.extracted_pages)))
@@ -76,7 +69,6 @@ def pdf_text_page_lines(
     pdf_reader: PdfReader | io.BytesIO | bytes,
     debug_path: Path | None = None,
     page_indices: list[int] | None = None,
-    replace_byte_codes: dict[bytes, bytes] | None = None,
     **kwargs,  # prevent errors due to bad args in upstream config dicts
 ) -> list[list[str]]:
     """
@@ -97,20 +89,12 @@ def pdf_text_page_lines(
             Defaults to None.
         page_indices (list[int] | None): if provided, only extract text from
             the listed page indices. Default is None (extract all pages).
-        replace_byte_codes (dict[bytes, bytes] | None): if supplied, raw
-            text is cast to bytes, the dict keys are replaced with values,
-            and resulting bytes are cast back to text. Used to replace custom
-            glyphs defined in PDFs w/ (roughtly) equivalent unicode charcters,
-            e.g. 'anesthesia billing print set' checkbox handling.
 
     Returns:
         list[list[str]]: a list of lines of text extracted for each page
     """
     return [
-        pg.splitlines()
-        for pg in pdf_text_pages(
-            pdf_reader, debug_path, page_indices, replace_byte_codes, **kwargs
-        )
+        pg.splitlines() for pg in pdf_text_pages(pdf_reader, debug_path, page_indices, **kwargs)
     ]
 
 

--- a/pypdftotext/__init__.py
+++ b/pypdftotext/__init__.py
@@ -1,6 +1,6 @@
 """Extract text from pdf pages from codebehind or Azure OCR as required"""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 import io
 import logging

--- a/pypdftotext/_config.py
+++ b/pypdftotext/_config.py
@@ -35,6 +35,7 @@ class PyPdfToTextConfigOverrides(TypedDict, total=False):
     SCALE_WEIGHT: float
     MIN_OCR_ROTATION_DEGREES: float
     SUPPRESS_EMBEDDED_TEXT: bool
+    REPLACE_BYTE_CODES: dict[bytes, bytes]
     OCR_HANDWRITTEN_CONFIDENCE_LIMIT: float
     AWS_ACCESS_KEY_ID: str | None
     AWS_SECRET_ACCESS_KEY: str | None
@@ -122,6 +123,10 @@ class _ConfigMixIn:
     SUPPRESS_EMBEDDED_TEXT: bool = False
     """if true, embedded text extraction will not be attempted. Assuming OCR
     is available, all pages will be OCR'd by default."""
+    REPLACE_BYTE_CODES: dict[bytes, bytes] = field(default_factory=dict)
+    """A series of byte code substitutions to make in the final extracted text,
+    e.g. replacing pdf 'encoded font' checkbox representations with a standard
+    unicode ☑ byte sequence."""
     OCR_HANDWRITTEN_CONFIDENCE_LIMIT: float = 0.8
     """Azure must be at least this confident that a given span is handwritten
     in order for it to count when determining handwritten character percentage."""

--- a/pypdftotext/_config.py
+++ b/pypdftotext/_config.py
@@ -36,6 +36,7 @@ class PyPdfToTextConfigOverrides(TypedDict, total=False):
     MIN_OCR_ROTATION_DEGREES: float
     SUPPRESS_EMBEDDED_TEXT: bool
     REPLACE_BYTE_CODES: dict[bytes, bytes]
+    MAX_WORKERS: int
     OCR_HANDWRITTEN_CONFIDENCE_LIMIT: float
     AWS_ACCESS_KEY_ID: str | None
     AWS_SECRET_ACCESS_KEY: str | None
@@ -127,6 +128,9 @@ class _ConfigMixIn:
     """A series of byte code substitutions to make in the final extracted text,
     e.g. replacing pdf 'encoded font' checkbox representations with a standard
     unicode ☑ byte sequence."""
+    MAX_WORKERS: int = 10
+    """The maximum number of threads to initialize during PdfExtractBatch
+    parallel operations."""
     OCR_HANDWRITTEN_CONFIDENCE_LIMIT: float = 0.8
     """Azure must be at least this confident that a given span is handwritten
     in order for it to count when determining handwritten character percentage."""

--- a/pypdftotext/batch.py
+++ b/pypdftotext/batch.py
@@ -81,7 +81,7 @@ class PdfExtractBatch:
         if len(s3_uris) <= 1:
             return pdf_extracts, {}
         with ThreadPoolExecutor(
-            max_workers=min(len(s3_uris), self.kwargs.get("max_workers", 10))
+            max_workers=min(len(s3_uris), self.config.MAX_WORKERS)
         ) as executor:
 
             futures: list[Future[tuple[str, PdfExtract | Exception]]] = []
@@ -184,7 +184,7 @@ class PdfExtractBatch:
 
         # Process PDFs in parallel using ThreadPoolExecutor
         with ThreadPoolExecutor(
-            max_workers=min(len(ocr_pdfs), self.kwargs.get("max_workers", 10))
+            max_workers=min(len(ocr_pdfs), self.config.MAX_WORKERS)
         ) as executor:
 
             futures: list[Future[tuple[str, PdfExtract]]] = []

--- a/pypdftotext/pdf_extract.py
+++ b/pypdftotext/pdf_extract.py
@@ -103,7 +103,6 @@ class PdfExtract:
         self.corruption_detected: bool = False
         self.body: bytes
         self.debug_path: Path | None = kwargs.get("debug_path")
-        self.replace_byte_codes: dict[bytes, bytes] | None = kwargs.get("replace_byte_codes")
         self.compressed: bool = kwargs.get("compressed", False)
         self._extracted_pages: list[ExtractedPage] | None = kwargs.get("init_extracted_pages")
         self._azure: AzureDocIntelIntegrator | None = kwargs.get("azure")
@@ -280,10 +279,10 @@ class PdfExtract:
             self.ocr(azure)
 
         # perform byte code substitutions per 'replace_byte_codes' arg
-        if self.replace_byte_codes:
+        if self.config.REPLACE_BYTE_CODES:
             replacements = [
                 (old_bytes.decode(), new_bytes.decode())
-                for old_bytes, new_bytes in self.replace_byte_codes.items()
+                for old_bytes, new_bytes in self.config.REPLACE_BYTE_CODES.items()
             ]
             for ext_pg in self._extracted_pages:
                 if not ext_pg.text:
@@ -314,7 +313,7 @@ class PdfExtract:
             else:
                 replacements = [
                     (old_bytes.decode(), new_bytes.decode())
-                    for old_bytes, new_bytes in (self.replace_byte_codes or {}).items()
+                    for old_bytes, new_bytes in (self.config.REPLACE_BYTE_CODES or {}).items()
                 ]
 
             ocr_pages = azure.ocr_pages(self.body, self.ocr_page_idxs)

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -178,7 +178,9 @@ class TestPdfExtract(unittest.TestCase):
     def test_replace_byte_codes(self):
         """Test custom glyph replacement parameter."""
         replacements = {b"\x00\x01": b"\xe2\x98\x90"}
-        pdf = PdfExtract(self.deid_epic_pdf, replace_byte_codes=replacements)
+        pdf = PdfExtract(
+            self.deid_epic_pdf, PyPdfToTextConfig(overrides={"REPLACE_BYTE_CODES": replacements})
+        )
         # Just verify it doesn't crash
         self.assertIsInstance(pdf.text, str)
 


### PR DESCRIPTION
- Parallelize s3 downloads in PdfExtractBatch
- Move `replace_byte_codes` kwarg to `PyPdfToTextConfig.REPLACE_BYTE_CODES` for easier spec management