### PR TITLE
Add selection mark support and remove numpy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ pypdftotext is a Python package that intelligently extracts text from PDF files.
 - 🚀 **Fast embedded text extraction** using pypdf's layout mode
 - 🔄 **Automatic OCR fallback** via Azure Document Intelligence when needed
 - 🚛 **Batch processing** with parallel OCR for multiple PDFs
-- 🧵 **Thread-safe operations** with the `PdfExtract` class
+- 🧵 **Stateful extraction** with the `PdfExtract` class
 - 📦 **S3 support** for reading PDFs directly from AWS S3
 - 🖼️ **Image compression** to reduce PDF file sizes
 - ✍️ **Handwritten text detection** with confidence scoring
 - 📄 **Page manipulation** - create child PDFs and extract page subsets
-- ⚙️ **Flexible Configuration** with built in env support multiple inheritance options
+- ⚙️ **Flexible configuration** with built-in env support and multiple inheritance options
 
 ## Installation
 
@@ -40,7 +40,7 @@ pip install "pypdftotext[image]"
 # For all optional features (s3 and pillow)
 pip install "pypdftotext[full]"
 
-# For development (full + boto3-types[s3], pytest, pytest-cov)
+# For development (full + boto3-stubs[s3], pytest, pytest-cov)
 pip install "pypdftotext[dev]"
 ```
 
@@ -116,13 +116,13 @@ for i, page_text in enumerate(extract.text_pages):
 
 #### Compress Images in Scanned PDFs to Reduce File Size or Improve OCR
 
-> NOTE: Requires the optional `pypdftotext[images]` installation.
+> NOTE: Requires the optional `pypdftotext[image]` installation.
 
 > NOTE: Perform this step _before_ accessing text/text_pages to use the compressed PDF for OCR. Otherwise, text will already be extracted from the original version and will not be re-extracted.
 
 ```python
 extract.compress_images(  # always converts images to greyscale
-    white_point = 200,  # pixels with values from 201 to 255 are set to 256 (aka white) to remove scanner artifacts
+    white_point = 200,  # pixels with values from 201 to 255 are set to 255 (white) to remove scanner artifacts
     aspect_tolerance=0.01,  # resizes images whose aspect ratios (width/height) are within 0.01 of the page aspect ratio
     max_overscale = 1.5,  # images having a width more than 1.5x the displayed width of the PDF page are downsampled to 1.5x
 )
@@ -177,13 +177,15 @@ If an S3 URI (e.g. `s3://my-bucket/path/to/document.pdf`) is supplied as the `pd
 
 OCR is automatically triggered when:
 1. The ratio of low-text pages exceeds `TRIGGER_OCR_PAGE_RATIO` (default: 99% of pages)
-2. A page is considered "low-text" if it has ≤ `MIN_LINES_OCR_TRIGGER` lines (default: 1)
+2. A page is considered "low-text" if it has < `MIN_LINES_OCR_TRIGGER` lines (default: 1)
 
 Example: OCR only when 50% of pages have fewer than 5 lines:
 ```python
 config = PyPdfToTextConfig(
-    MIN_LINES_OCR_TRIGGER=5,
-    TRIGGER_OCR_PAGE_RATIO=0.5
+    overrides={
+        "MIN_LINES_OCR_TRIGGER": 5,
+        "TRIGGER_OCR_PAGE_RATIO": 0.5,
+    }
 )
 ```
 

--- a/pypdftotext/__init__.py
+++ b/pypdftotext/__init__.py
@@ -1,6 +1,6 @@
 """Extract text from pdf pages from codebehind or Azure OCR as required"""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 import io
 import logging

--- a/pypdftotext/_config.py
+++ b/pypdftotext/_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, InitVar, field
-from typing import cast, Any, TypedDict
+from typing import cast, Any, Literal, TypedDict
 
 
 logger = logging.getLogger(__name__)
@@ -22,6 +22,7 @@ class PyPdfToTextConfigOverrides(TypedDict, total=False):
     AZURE_DOCINTEL_SUBSCRIPTION_KEY: str
     AZURE_DOCINTEL_AUTO_CLIENT: bool
     AZURE_DOCINTEL_TIMEOUT: int
+    AZURE_DOCINTEL_MODEL: Literal["prebuilt-read", "prebuilt-layout"]
     DISABLE_OCR: bool
     DISABLE_PROGRESS_BAR: bool
     PROGRESS_BAR_POSITION: int | None
@@ -38,6 +39,7 @@ class PyPdfToTextConfigOverrides(TypedDict, total=False):
     REPLACE_BYTE_CODES: dict[bytes, bytes]
     MAX_WORKERS: int
     OCR_HANDWRITTEN_CONFIDENCE_LIMIT: float
+    OCR_SELECTION_MARK_CONFIDENCE_LIMIT: float
     AWS_ACCESS_KEY_ID: str | None
     AWS_SECRET_ACCESS_KEY: str | None
     AWS_SESSION_TOKEN: str | None
@@ -76,6 +78,8 @@ class _ConfigMixIn:
     upon first use."""
     AZURE_DOCINTEL_TIMEOUT: int = 60
     """How long to wait for Azure OCR results before timing out. Default is 60."""
+    AZURE_DOCINTEL_MODEL: Literal["prebuilt-read", "prebuilt-layout"] = "prebuilt-read"
+    """The value to use for the 'model' parameter when calling the Azure API"""
     DISABLE_OCR: bool = False
     """Set to True to disable all OCR operations and return 'code behind' text
     only."""
@@ -139,6 +143,9 @@ class _ConfigMixIn:
     OCR_HANDWRITTEN_CONFIDENCE_LIMIT: float = 0.8
     """Azure must be at least this confident that a given span is handwritten
     in order for it to count when determining handwritten character percentage."""
+    OCR_SELECTION_MARK_CONFIDENCE_LIMIT: float = 0.8
+    """Azure must be at least this confident that a given span is a selection mark
+    in order for it to be rendered alongside standard text output."""
     AWS_ACCESS_KEY_ID: str | None = field(default_factory=lambda: os.getenv("AWS_ACCESS_KEY_ID"))
     """AWS access key ID for the credentials that will be used to pull source
     PDFs from S3 if installed with "s3" extra (`pip install pypdftotext["s3"]`)"""

--- a/pypdftotext/_config.py
+++ b/pypdftotext/_config.py
@@ -79,7 +79,7 @@ class _ConfigMixIn:
     AZURE_DOCINTEL_TIMEOUT: int = 60
     """How long to wait for Azure OCR results before timing out. Default is 60."""
     AZURE_DOCINTEL_MODEL: Literal["prebuilt-read", "prebuilt-layout"] = "prebuilt-read"
-    """The value to use for the 'model' parameter when calling the Azure API"""
+    """The value to use for the 'model_id' parameter when calling the Azure API"""
     DISABLE_OCR: bool = False
     """Set to True to disable all OCR operations and return 'code behind' text
     only."""

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -160,12 +160,7 @@ class AzureDocIntelIntegrator:
             # checkboxes and the like with ':selected:' or ':unselected:' and includes this
             # unrendered text in span offsets (like an asshole).
             page_length_reduction = sum(
-                (
-                    10  # 10 chars in ':selected:'
-                    if sel.state == "selected"
-                    else 12  # 12 chars in ':unselected:'
-                )
-                for sel in _selected_page.selection_marks or []
+                sel.span.length for sel in _selected_page.selection_marks or []
             )
             # finally, we'll ignore newline chars that occur in the page span
             page_length_reduction += self.last_result.content[page_start:page_end].count("\n")

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -81,7 +81,7 @@ class AzureDocIntelIntegrator:
         assert self.client is not None
         logger.info("Sending pdf of %s bytes for OCR of %s pages.", len(pdf), len(pages))
         poller: AnalyzeDocumentLROPoller = self.client.begin_analyze_document(
-            model_id="prebuilt-read",
+            model_id=self.config.AZURE_DOCINTEL_MODEL,
             body=io.BytesIO(pdf),
             pages=",".join(str(pg + 1) for pg in pages),
         )
@@ -131,7 +131,8 @@ class AzureDocIntelIntegrator:
             # offset + length as the page end.
             page_start = min(span.offset for span in _selected_page.spans)
             page_end = max(span.offset + span.length for span in _selected_page.spans)
-            if page_end - page_start <= 0:
+            page_length = page_end - page_start
+            if page_length <= 0:
                 # whoops! something's wrong. We should probably throw an exception here, but
                 # we'll fail open for now as it fits our use case.
                 logger.warning(
@@ -155,9 +156,22 @@ class AzureDocIntelIntegrator:
                 ),
                 start=0,
             )
+            # Now we'll account for selection marks since prebuilt-layout output replaces
+            # checkboxes and the like with ':selected:' or ':unselected:' and includes this
+            # unrendered text in span offsets (like an asshole).
+            page_length_reduction = sum(
+                (
+                    10  # 10 chars in ':selected:'
+                    if sel.state == "selected"
+                    else 12  # 12 chars in ':unselected:'
+                )
+                for sel in _selected_page.selection_marks or []
+            )
+            # finally, we'll ignore newline chars that occur in the page span
+            page_length_reduction += self.last_result.content[page_start:page_end].count("\n")
             # Guess we'll cap our value at 1.0. We should probably throw and exception here
-            # also, but again we'll fail open for now as it suites our use case.
-            ratio = handwritten_length / (page_end - page_start)
+            # also, but again we'll fail open for now as it suits our use case.
+            ratio = handwritten_length / (page_end - page_start - page_length_reduction)
             if ratio > 1.0:
                 logger.warning("Handwritten ratio of page index at %s capped at 1.0", page_index)
                 return 1.0

--- a/pypdftotext/pdf_extract.py
+++ b/pypdftotext/pdf_extract.py
@@ -295,6 +295,12 @@ class PdfExtract:
                 (self.debug_path / "ocr_pages.json").write_text(
                     json.dumps(ocr_pages, indent=2, default=str), "utf-8"
                 )
+                (self.debug_path / "azure.json").write_text(
+                    json.dumps(azure.last_result.as_dict(), indent=2), "utf-8"
+                )
+                (self.debug_path / "azure_content.txt").write_text(
+                    azure.last_result.content, "utf-8"
+                )
             for ocr_idx, og_pg_idx in enumerate(self.ocr_page_idxs):
                 ext_pg = self.extracted_pages[og_pg_idx]
                 txt = ocr_pages[ocr_idx]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-dependencies = ["pypdf==6.0", "tqdm", "numpy>=2.0.0", "azure-ai-documentintelligence>=1.0.0"]
+dependencies = ["pypdf==6.0", "tqdm", "azure-ai-documentintelligence>=1.0.0"]
 
 [project.optional-dependencies]
 s3 = ["boto3"]
@@ -26,7 +26,6 @@ dev = [
   "boto3",
   "pillow>=8.0.0",
   "boto3-stubs[s3]",
-  "numpy>=2.0.0",
   "pytest>=7.0.0",
   "pytest-cov>=4.0.0",
 ]


### PR DESCRIPTION
## Summary

- **Add selection mark (checkbox) support**: Render Azure OCR selection marks as ✅ (selected) or ☐ (unselected) in layout output with configurable confidence threshold
- **Add configurable Azure model**: New `AZURE_DOCINTEL_MODEL` config parameter to select between "prebuilt-read" and "prebuilt-layout" models
- **Remove numpy dependency**: Replace numpy operations with native Python for simpler, lighter installation
- **Fix handwritten ratio calculation**: Account for selection mark text lengths and newlines in ratio computation
- **Add debug output**: Include azure.json and azure_content.txt in debug output
- **Update docstrings**: Document new DocumentSelectionMark support in layout.py

## Changes

### New Config Parameters
- `AZURE_DOCINTEL_MODEL`: Select Azure model ("prebuilt-read" or "prebuilt-layout")
- `OCR_SELECTION_MARK_CONFIDENCE_LIMIT`: Confidence threshold for rendering selection marks (default: 0.8)

### Performance Improvements
- Cache match_ratio scores to avoid redundant computation in header/footer detection
- Replace `sorted(...)[-1]` with `max()` for O(n) vs O(n log n) lookup
- Simplify waist calculation with list multiplication instead of while loop

### Dependency Changes
- Remove numpy from dependencies (pyproject.toml)

## Test plan
- [x] All doctests pass
- [x] Module imports successfully without numpy

🤖 Generated with [Claude Code](https://claude.com/claude-code)