### PR TITLE
Dedup outline items w/out index growth

### DIFF
--- a/pypdftotext/__init__.py
+++ b/pypdftotext/__init__.py
@@ -1,6 +1,6 @@
 """Extract text from pdf pages from codebehind or Azure OCR as required"""
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 import io
 import logging

--- a/pypdftotext/pdf_extract.py
+++ b/pypdftotext/pdf_extract.py
@@ -592,9 +592,10 @@ class PdfExtract:
                 continue
             # dedup destinations with numeric idxs
             dup_idx = 0
+            og_name = name
             while name in seen_names:
                 dup_idx += 1
-                name = f"{name} {dup_idx}"
+                name = f"{og_name} {dup_idx}"
             seen_names.add(name)
 
             self.writer.add_outline_item(name, page_idx)


### PR DESCRIPTION
prior to fix, 3 "case times' sections would be added as "Case Times" "Case Times 1" and Case Times 1 2". Fix makes the last "Case Times 2".