### PR TITLE
Pdf name logging and config API simplification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ pip install -e ".[dev]"  # All of the above + pytest, pytest-cov, and type stubs
    - `PdfExtract` class orchestrates the entire extraction workflow
    - Accepts `str | Path | bytes | io.BytesIO | PdfReader`; a `str` may be an `s3://` URI
    - `config` param accepts `PyPdfToTextConfig`, a dict of overrides, or `None`
+   - `pdf_name` keyword-only param: human-readable identifier for logging in parallel scenarios. Auto-derived from input (path stem, PdfReader metadata title, or SHA-256 hash fallback) if not supplied.
    - Key methods: `remove_pages()`, `child()`, `clip_pages()`, `compress_images()`, `add_named_destinations()`
    - Key properties: `text`, `text_pages`, `text_page_lines`, `extracted_pages`, `reader`, `writer`
    - `handwritten_ratio(page_index)` returns the handwritten ratio for a given page (method, not module-level function)
@@ -100,6 +101,7 @@ pip install -e ".[dev]"  # All of the above + pytest, pytest-cov, and type stubs
 
 ### Key Design Patterns
 
+- **Keyword-Only Parameters**: `PdfExtract.__init__` uses `*` separator — params like `pdf_name` are keyword-only, followed by `**kwargs` for internal params (`debug_path`, `compressed`, `init_extracted_pages`, `_batch_mode`)
 - **Lazy Initialization**: Azure OCR client created only when needed
 - **Fallback Strategy**: Attempts embedded text extraction first, falls back to OCR based on configurable thresholds
 - **Corruption Detection**: Validates extracted text length against `MAX_CHARS_PER_PDF_PAGE` to detect malformed PDFs
@@ -161,6 +163,8 @@ These can also be set programmatically after import via the `constants` global s
 ### Thread Safety
 
 - The current implementation uses a singleton Azure client - consider thread safety when implementing concurrent processing
+- `PdfReader` (and the `reader` property) is NOT thread safe — avoid triggering lazy reader init from multiple threads
+- `pdf_name` derivation avoids triggering lazy reader init for bytes/BytesIO inputs for this reason
 - Progress bars support positioning for multi-threaded scenarios via `pbar_position`
 
 ## Development Guardrails
@@ -168,6 +172,8 @@ These can also be set programmatically after import via the `constants` global s
 ### Testing
 
 Provide test coverage for all new public functions, classes, and methods. Prefer doctest for self-contained methods where a docstring `Example:` section makes sense. Use `tests/` modules for tests requiring fixtures, mocks, or multi-step setup.
+
+`PdfReader.metadata` is a read-only property — use `unittest.mock.patch.object(type(reader), "metadata", new_callable=PropertyMock)` to mock it in tests.
 
 ### Type Checking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ pip install -e ".[dev]"  # All of the above + pytest, pytest-cov, and type stubs
 3. **PDF Extraction Engine** (`pdf_extract.py`):
    - `PdfExtract` class orchestrates the entire extraction workflow
    - Accepts `str | Path | bytes | io.BytesIO | PdfReader`; a `str` may be an `s3://` URI
+   - `config` param accepts `PyPdfToTextConfig`, a dict of overrides, or `None`
    - Key methods: `remove_pages()`, `child()`, `clip_pages()`, `compress_images()`, `add_named_destinations()`
    - Key properties: `text`, `text_pages`, `text_page_lines`, `extracted_pages`, `reader`, `writer`
    - `handwritten_ratio(page_index)` returns the handwritten ratio for a given page (method, not module-level function)
@@ -91,6 +92,7 @@ pip install -e ".[dev]"  # All of the above + pytest, pytest-cov, and type stubs
 
 7. **Batch Processing** (`batch.py`):
    - `PdfExtractBatch` for submitting multiple PDFs to Azure OCR in a single API call
+   - `config` param accepts `PyPdfToTextConfig`, a dict of overrides, or `None` (same as `PdfExtract`)
 
 8. **Header/Footer Detection** (`header_footer_detection.py`, `page_fingerprint.py`):
    - `assign_headers_and_footers()`: heuristically marks repeated page elements across documents

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pypdftotext is a Python package that intelligently extracts text from PDF files.
 - 🖼️ **Image compression** to reduce PDF file sizes
 - ✍️ **Handwritten text detection** with confidence scoring
 - 📄 **Page manipulation** - create child PDFs and extract page subsets
+- 📑 **Header/footer detection** - heuristic stripping of repeated page elements
 - ⚙️ **Flexible configuration** with built-in env support and multiple inheritance options
 
 ## Installation
@@ -57,9 +58,10 @@ pip install "pypdftotext[dev]"
 
 ### Enable Azure OCR (optional)
 
-> NOTE: If OCR has not been configured, only the text embedded directly in the pdf will be returned (using [pypdf's](https://pypdf.readthedocs.io/en/stable/user/extract-text.html) layout mode).
+> NOTE: If OCR has not been configured, only the text embedded directly in the pdf will be returned (using [pypdf's](https://pypdf.readthedocs.io/en/stable/user/extract-text.html) layout mode). You can also explicitly disable OCR by setting `DISABLE_OCR=True` in your config.
 
 #### OCR Prerequisites
+
 - An Azure Subscription ([create one for free](https://azure.microsoft.com/free/cognitive-services/))
 - An Azure Document Intelligence resource ([create one](https://portal.azure.com/#create/Microsoft.CognitiveServicesFormRecognizer))
 
@@ -67,14 +69,14 @@ pip install "pypdftotext[dev]"
 
 > NOTE: The same behaviors apply to the AWS_* settings for pulling PDFs from S3.
 
-##### You can set your Endpoint and Subscription Key globally via env vars:
+##### You can set your Endpoint and Subscription Key globally via env vars
 
 ```bash
 export AZURE_DOCINTEL_ENDPOINT="https://your-resource.cognitiveservices.azure.com/"
 export AZURE_DOCINTEL_SUBSCRIPTION_KEY="your-subscription-key"
 ```
 
-##### Or via the `constants` module:
+##### Or via the `constants` module
 
 ```python
 from pypdftotext import constants
@@ -87,10 +89,17 @@ You can also set these values for individual instances of the PyPdfToTextConfig 
 ### Basic Usage
 
 #### Create a PdfExtract Instance
+
 ```python
 from pypdftotext import PdfExtract
 
 extract = PdfExtract("document.pdf")
+
+# Optional: supply a human-readable name for log output (useful in parallel scenarios)
+extract = PdfExtract("document.pdf", pdf_name="quarterly-report")
+
+# The config parameter also accepts a plain dict of overrides
+extract = PdfExtract("document.pdf", config={"DISABLE_OCR": True})
 ```
 
 #### Optional: Customize the Config
@@ -122,9 +131,9 @@ for i, page_text in enumerate(extract.text_pages):
 
 ```python
 extract.compress_images(  # always converts images to greyscale
-    white_point = 200,  # pixels with values from 201 to 255 are set to 255 (white) to remove scanner artifacts
-    aspect_tolerance=0.01,  # resizes images whose aspect ratios (width/height) are within 0.01 of the page aspect ratio
-    max_overscale = 1.5,  # images having a width more than 1.5x the displayed width of the PDF page are downsampled to 1.5x
+    white_point = 220,  # pixels with values from 221 to 255 are set to 255 (white) to remove scanner artifacts
+    aspect_tolerance=0.001,  # resizes images whose aspect ratios (width/height) are within 0.001 of the page aspect ratio
+    max_overscale = 2,  # images having a width more than 2x the displayed width of the PDF page are downsampled to 2x
 )
 ```
 
@@ -146,12 +155,20 @@ extract_child = extract.child((0, 9))  # useful for passing config and metadata 
 clipped_pages_pdf_bytes = extract_child.clip_pages([0, 2, 4])  # useful for quick splitting.
 ```
 
+`child()` also supports `remove_from_parent=True` to move pages out of the parent, and `raise_on_empty=False` to suppress `AllPagesRemovedError` when all pages would be removed.
+
+#### Adding Bookmarks
+
+```python
+extract.add_named_destinations([("Chapter 1", 0), ("Chapter 2", 5)])
+```
+
 ### Batch Processing
 
 Process multiple PDFs efficiently with parallel OCR:
 
 ```python
-from pypdftotext.batch import PdfExtractBatch
+from pypdftotext import PdfExtractBatch
 
 # Process multiple PDFs (list or dict)
 pdfs = ["file1.pdf", "file2.pdf", "file3.pdf"]
@@ -166,9 +183,10 @@ for name, pdf_extract in results.items():
     print(f"{name}: {len(pdf_extract.text)} characters extracted")
 ```
 
-Batch processing extracts embedded text sequentially, then performs OCR in parallel for all PDFs that need it.
+Batch processing extracts embedded text sequentially, then performs OCR in parallel for all PDFs that need it. It also heuristically detects and strips repeated headers and footers across pages (configurable via `MAX_HEADER_LINES`, `MAX_FOOTER_LINES`, and related config options; disabled by default).
 
 ### S3 Support
+
 If an S3 URI (e.g. `s3://my-bucket/path/to/document.pdf`) is supplied as the `pdf` parameter, `PdfExtract` will attempt to pull the bytes from the supplied bucket/key. AWS credentials with proper permissions must be supplied as env vars or set programmatically [as described for Azure OCR above](#ocr-configuration) or an error will result.
 
 ## Implementation Details
@@ -176,10 +194,12 @@ If an S3 URI (e.g. `s3://my-bucket/path/to/document.pdf`) is supplied as the `pd
 ### OCR Triggering Logic
 
 OCR is automatically triggered when:
+
 1. The ratio of low-text pages exceeds `TRIGGER_OCR_PAGE_RATIO` (default: 99% of pages)
 2. A page is considered "low-text" if it has < `MIN_LINES_OCR_TRIGGER` lines (default: 1)
 
 Example: OCR only when 50% of pages have fewer than 5 lines:
+
 ```python
 config = PyPdfToTextConfig(
     overrides={
@@ -211,5 +231,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Acknowledgments
 
 Built on top of:
+
 - [pypdf](https://github.com/py-pdf/pypdf) for PDF parsing
 - [Azure Document Intelligence](https://azure.microsoft.com/en-us/services/cognitive-services/form-recognizer/) for OCR capabilities

--- a/pypdftotext/__init__.py
+++ b/pypdftotext/__init__.py
@@ -1,6 +1,6 @@
 """Extract text from pdf pages from codebehind or Azure OCR as required"""
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 import io
 import logging

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -58,13 +58,14 @@ class AzureDocIntelIntegrator:
         """Clear last_result from previous run."""
         self.last_result = AnalyzeResult({})
 
-    def ocr_pages(self, pdf: bytes, pages: list[int]) -> list[str]:
+    def ocr_pages(self, pdf: bytes, pages: list[int], pdf_name: str = "") -> list[str]:
         """
         Read the text from supplied pdf page indices.
 
         Args:
             pdf: bytes of a pdf file
             pages: list of pdf page indices to OCR
+            pdf_name: optional identifier included in log messages for parallel tracing
 
         Returns:
             list[str]: list of strings containing structured text extracted
@@ -78,14 +79,17 @@ class AzureDocIntelIntegrator:
             )
             return []
         assert self.client is not None
-        logger.info("Sending pdf of %s bytes for OCR of %s pages.", len(pdf), len(pages))
+        prefix = f"[{pdf_name}] " if pdf_name else ""
+        logger.info("%sSending pdf of %s bytes for OCR of %s pages.", prefix, len(pdf), len(pages))
         poller: AnalyzeDocumentLROPoller = self.client.begin_analyze_document(
             model_id=self.config.AZURE_DOCINTEL_MODEL,
             body=io.BytesIO(pdf),
             pages=",".join(str(pg + 1) for pg in pages),
         )
         self.last_result = poller.result(self.config.AZURE_DOCINTEL_TIMEOUT)
-        logger.info("%s pages OCR'd successfully. Creating fixed width pages.", len(pages))
+        logger.info(
+            "%s%s pages OCR'd successfully. Creating fixed width pages.", prefix, len(pages)
+        )
         ocr_pbar = tqdm(
             self.last_result.pages,
             desc="Processing OCR results...",

--- a/pypdftotext/batch.py
+++ b/pypdftotext/batch.py
@@ -12,7 +12,7 @@ from azure.core.exceptions import AzureError
 from pypdf import PdfReader
 from tqdm import tqdm
 
-from ._config import PyPdfToTextConfig
+from ._config import PyPdfToTextConfig, PyPdfToTextConfigOverrides
 from .azure_docintel_integrator import AzureDocIntelIntegrator
 from .header_footer_detection import assign_headers_and_footers
 from .pdf_extract import PdfExtract
@@ -48,7 +48,7 @@ class PdfExtractBatch:
             Sequence[str | Path | bytes | io.BytesIO | PdfReader]
             | Mapping[str, str | Path | bytes | io.BytesIO | PdfReader]
         ),
-        config: PyPdfToTextConfig | None = None,
+        config: PyPdfToTextConfig | PyPdfToTextConfigOverrides | None = None,
         **kwargs,
     ) -> None:
         if not isinstance(pdfs, (list, dict)):
@@ -58,6 +58,8 @@ class PdfExtractBatch:
         self.pdfs = (
             pdfs if isinstance(pdfs, dict) else {f"PDF[{i}]": pdf for i, pdf in enumerate(pdfs)}
         )
+        if isinstance(config, dict):
+            config = PyPdfToTextConfig(overrides=config)
         self.config = config or PyPdfToTextConfig()
         self.kwargs = kwargs
         logger.info("Starting batch extraction for %s PDFs", len(self.pdfs))

--- a/pypdftotext/batch.py
+++ b/pypdftotext/batch.py
@@ -74,7 +74,10 @@ class PdfExtractBatch:
         }
         pdf_extracts: dict[str, PdfExtract] = {
             pdf_name: PdfExtract(
-                pdf=pdf, config=self.config, **{**self.kwargs, "_batch_mode": True}
+                pdf=pdf,
+                config=self.config,
+                pdf_name=pdf_name,
+                **{**self.kwargs, "_batch_mode": True},
             )
             for pdf_name, pdf in self.pdfs.items()
             if pdf_name not in s3_uris or len(s3_uris) == 1
@@ -114,7 +117,10 @@ class PdfExtractBatch:
         pdf_name, s3_uri = s3_uri_tuple
         try:
             extract = PdfExtract(
-                pdf=s3_uri, config=self.config, **{**self.kwargs, "_batch_mode": True}
+                pdf=s3_uri,
+                config=self.config,
+                pdf_name=pdf_name,
+                **{**self.kwargs, "_batch_mode": True},
             )
             return pdf_name, extract
         except Exception as e:  # noqa: BLE001  # batch must survive per-item S3 failures; caller expects Exception in result

--- a/pypdftotext/batch.py
+++ b/pypdftotext/batch.py
@@ -32,7 +32,10 @@ class PdfExtractBatch:
 
     Args:
         pdfs: List or mapping of PDF inputs (str | Path | bytes | io.BytesIO | PdfReader)
-        config: Configuration to use for all PDFs (defaults to PyPdfToTextConfig())
+        config: a PyPdfToTextConfig instance, a dict of config-field overrides
+            (e.g. ``{"DISABLE_OCR": True}``), or None. A dict is converted to
+            ``PyPdfToTextConfig(overrides=config)`` automatically. Defaults to
+            ``PyPdfToTextConfig()``.
         **kwargs: Additional arguments passed to PdfExtract instances
 
     Usage:
@@ -58,6 +61,11 @@ class PdfExtractBatch:
         self.pdfs = (
             pdfs if isinstance(pdfs, dict) else {f"PDF[{i}]": pdf for i, pdf in enumerate(pdfs)}
         )
+        if kwargs.pop("pdf_name", None) is not None:
+            logger.warning(
+                "pdf_name is not a valid kwarg for PdfExtractBatch, dumbass — "
+                "each PDF's name is derived from its dict key or list index. Ignoring."
+            )
         if isinstance(config, dict):
             config = PyPdfToTextConfig(overrides=config)
         self.config = config or PyPdfToTextConfig()

--- a/pypdftotext/pdf_extract.py
+++ b/pypdftotext/pdf_extract.py
@@ -8,7 +8,7 @@ import json
 import logging
 import re
 from collections.abc import Callable
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import TYPE_CHECKING, overload
 
 from pypdf import PageObject, PdfReader, PdfWriter
@@ -62,13 +62,15 @@ class PdfExtract:
         pdf (str | Path | bytes | io.BytesIO | PdfReader): if str, check for s3
             download if boto3 is installed and value is an s3 uri (i.e. prefixed 's3://').
             otherwise attempt read from disk.
-        config: a PyPdfToTextConfig instance that inherits from the global base config
-            `constants` by default. See PyPdfToTextConfig docstring for more info.
+        config: a PyPdfToTextConfig instance, a dict of config-field overrides
+            (e.g. ``{"DISABLE_OCR": True}``), or None. A dict is converted to
+            ``PyPdfToTextConfig(overrides=config)`` automatically. Defaults to the
+            global base config ``constants``.
 
     KwArgs:
         pdf_name (str | None): optional human-readable identifier for this PDF.
             Used in log messages to distinguish PDFs during parallel processing.
-            Auto-derived from the input if not supplied (path stem, metadata title,
+            Auto-derived from the input if not supplied (filename, metadata title,
             or content hash).
         debug_path (Path | None, optional): Path to write pypdf debug files to.
             Defaults to None.
@@ -111,7 +113,7 @@ class PdfExtract:
             if pdf.startswith("s3://"):
                 logger.info(
                     "[%s] Pulling URI '%s' from S3",
-                    pdf_name or PurePosixPath(pdf).stem or pdf,
+                    pdf_name or pdf.rsplit("/", 1)[-1],
                     pdf,
                 )
                 bucket, _, key = pdf[5:].partition("/")
@@ -145,17 +147,20 @@ class PdfExtract:
         if explicit_name:
             return explicit_name
         if isinstance(pdf, str):
-            stem = PurePosixPath(pdf).stem if pdf.startswith("s3://") else Path(pdf).stem
-            if stem:
-                return stem
+            filename = pdf.rsplit("/", 1)[-1] if "/" in pdf else Path(pdf).name
+            if filename:
+                return filename
         elif isinstance(pdf, Path):
-            if pdf.stem:
-                return pdf.stem
+            if pdf.name:
+                return pdf.name
         elif isinstance(pdf, PdfReader):
             meta = self._reader.metadata if self._reader else None
             if meta and meta.title:
-                return meta.title
-        return f"pdf_{hashlib.sha256(self.body).hexdigest()[:8]}"
+                title = re.split(r"[\r\n\t]+", meta.title.strip(" \r\n\t"))[0].strip()
+                title = "".join(c for c in title if c.isprintable())
+                if title:
+                    return title[:256]  # cap at 256, a common filenae length constraint.
+        return f"{hashlib.sha256(self.body).hexdigest()[:8]}.pdf"
 
     @property
     def extracted_pages(self) -> list[ExtractedPage]:

--- a/pypdftotext/pdf_extract.py
+++ b/pypdftotext/pdf_extract.py
@@ -81,9 +81,11 @@ class PdfExtract:
     def __init__(
         self,
         pdf: str | Path | bytes | io.BytesIO | PdfReader,
-        config: PyPdfToTextConfig | None = None,
+        config: PyPdfToTextConfig | PyPdfToTextConfigOverrides | None = None,
         **kwargs,
     ) -> None:
+        if isinstance(config, dict):
+            config = PyPdfToTextConfig(overrides=config)
         self.config = config or PyPdfToTextConfig()
         self.corruption_detected: bool = False
         self.body: bytes

--- a/pypdftotext/pdf_extract.py
+++ b/pypdftotext/pdf_extract.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import logging
 import re
 from collections.abc import Callable
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, overload
 
 from pypdf import PageObject, PdfReader, PdfWriter
@@ -65,6 +66,10 @@ class PdfExtract:
             `constants` by default. See PyPdfToTextConfig docstring for more info.
 
     KwArgs:
+        pdf_name (str | None): optional human-readable identifier for this PDF.
+            Used in log messages to distinguish PDFs during parallel processing.
+            Auto-derived from the input if not supplied (path stem, metadata title,
+            or content hash).
         debug_path (Path | None, optional): Path to write pypdf debug files to.
             Defaults to None.
         replace_byte_codes (dict[bytes, bytes] | None): if supplied, raw
@@ -82,6 +87,8 @@ class PdfExtract:
         self,
         pdf: str | Path | bytes | io.BytesIO | PdfReader,
         config: PyPdfToTextConfig | PyPdfToTextConfigOverrides | None = None,
+        *,
+        pdf_name: str | None = None,
         **kwargs,
     ) -> None:
         if isinstance(config, dict):
@@ -102,7 +109,11 @@ class PdfExtract:
         # set initial body value
         if isinstance(pdf, str):
             if pdf.startswith("s3://"):
-                logger.info("Attempting to pull URI '%s' from s3", pdf)
+                logger.info(
+                    "[%s] Pulling URI '%s' from S3",
+                    pdf_name or PurePosixPath(pdf).stem or pdf,
+                    pdf,
+                )
                 bucket, _, key = pdf[5:].partition("/")
                 s3_object = self.s3.get_object(Bucket=bucket, Key=key)
                 self.body = s3_object["Body"].read()
@@ -122,6 +133,29 @@ class PdfExtract:
             self._reader = pdf
             assert isinstance(self._reader.stream, io.BytesIO)
             self.body = self._reader.stream.getvalue()
+
+        self.pdf_name = self._derive_pdf_name(pdf, pdf_name)
+
+    def _derive_pdf_name(
+        self,
+        pdf: str | Path | bytes | io.BytesIO | PdfReader,
+        explicit_name: str | None,
+    ) -> str:
+        """Derive a human-readable identifier for this PDF instance."""
+        if explicit_name:
+            return explicit_name
+        if isinstance(pdf, str):
+            stem = PurePosixPath(pdf).stem if pdf.startswith("s3://") else Path(pdf).stem
+            if stem:
+                return stem
+        elif isinstance(pdf, Path):
+            if pdf.stem:
+                return pdf.stem
+        elif isinstance(pdf, PdfReader):
+            meta = self._reader.metadata if self._reader else None
+            if meta and meta.title:
+                return meta.title
+        return f"pdf_{hashlib.sha256(self.body).hexdigest()[:8]}"
 
     @property
     def extracted_pages(self) -> list[ExtractedPage]:
@@ -158,7 +192,7 @@ class PdfExtract:
     def reader(self) -> PdfReader:
         """The PDF reader used for text extraction. **NOT THREAD SAFE.**"""
         if self._reader is None:
-            logger.debug("Initializing PdfReader for PdfExtract")
+            logger.debug("[%s] Initializing PdfReader", self.pdf_name)
             self._reader = PdfReader(io.BytesIO(self.body))
         return self._reader
 
@@ -167,7 +201,7 @@ class PdfExtract:
         """The PDF writer used for image compression, child creation,
         and page rotations. **NOT THREAD SAFE.**"""
         if self._writer is None:
-            logger.debug("Initializing PdfWriter for PdfExtract")
+            logger.debug("[%s] Initializing PdfWriter", self.pdf_name)
             if self._extracted_pages:
                 self._writer = PdfWriter()
                 self._writer.append(
@@ -218,7 +252,8 @@ class PdfExtract:
             if self._pbar:
                 self._pbar.set_postfix_str("!!! CORRUPTION DETECTED !!!")
             logger.warning(
-                "Clearing corrupt pdf text pg_idx=%s; len(txt)=%s > %s char limit.",
+                "[%s] Clearing corrupt pdf text pg_idx=%s; len(txt)=%s > %s char limit.",
+                self.pdf_name,
                 pg_idx,
                 len(txt),
                 self.config.MAX_CHARS_PER_PDF_PAGE,
@@ -305,7 +340,7 @@ class PdfExtract:
                     for old_bytes, new_bytes in (self.config.REPLACE_BYTE_CODES or {}).items()
                 ]
 
-            ocr_pages = azure.ocr_pages(self.body, self.ocr_page_idxs)
+            ocr_pages = azure.ocr_pages(self.body, self.ocr_page_idxs, pdf_name=self.pdf_name)
             if self.debug_path:
                 (self.debug_path / "ocr_pages.json").write_text(
                     json.dumps(ocr_pages, indent=2, default=str), "utf-8"
@@ -321,8 +356,9 @@ class PdfExtract:
                 txt = ocr_pages[ocr_idx]
                 if len(txt) > self.config.MAX_CHARS_PER_PDF_PAGE:
                     logger.warning(
-                        "Clearing corrupt OCR text pg_idx=%s; len(txt)=%s > %s char limit."
+                        "[%s] Clearing corrupt OCR text pg_idx=%s; len(txt)=%s > %s char limit."
                         " Does page contain multiple text orientations?",
+                        self.pdf_name,
                         og_pg_idx,
                         len(txt),
                         self.config.MAX_CHARS_PER_PDF_PAGE,
@@ -346,7 +382,7 @@ class PdfExtract:
                 ext_pg.azure_page = azure.page_at_index(og_pg_idx)
 
         if rotated_pages:
-            logger.debug("Regenerating PdfExtract body with corrected page orientations.")
+            logger.debug("[%s] Regenerating body with corrected page orientations.", self.pdf_name)
             self._regenerate_body()
 
     @overload
@@ -439,8 +475,9 @@ class PdfExtract:
                     "suppress this error and perform a no-op instead."
                 )
             logger.warning(
-                "remove_pages() would remove all pages — no-op performed. "
-                "Pass raise_on_empty=True (default) to raise AllPagesRemovedError instead."
+                "[%s] remove_pages() would remove all pages — no-op performed. "
+                "Pass raise_on_empty=True (default) to raise AllPagesRemovedError instead.",
+                self.pdf_name,
             )
             return
         if len(self._extracted_pages) < len(starting_pages):
@@ -453,6 +490,7 @@ class PdfExtract:
         config_overrides: PyPdfToTextConfigOverrides | None = None,
         remove_from_parent: bool = False,
         raise_on_empty: bool = True,
+        pdf_name: str | None = None,
     ) -> PdfExtract | None:
         """
         Run the 'page_indices' test function on all extracted pages and include
@@ -468,6 +506,8 @@ class PdfExtract:
             raise_on_empty (bool): When remove_from_parent=True, controls behavior if
                 all parent pages are selected. If True (default), raises
                 AllPagesRemovedError. If False, performs a no-op on the parent instead.
+            pdf_name (str | None): optional name for the child. Inherits parent's
+                pdf_name if not supplied.
 
         Returns:
             PdfExtract | None: a child instance containing the pages specified or
@@ -481,6 +521,7 @@ class PdfExtract:
         config_overrides: PyPdfToTextConfigOverrides | None = None,
         remove_from_parent: bool = False,
         raise_on_empty: bool = True,
+        pdf_name: str | None = None,
     ) -> PdfExtract:
         """
         Include pages at the indices supplied in 'page_indices'.
@@ -494,6 +535,8 @@ class PdfExtract:
             raise_on_empty (bool): When remove_from_parent=True, controls behavior if
                 all parent pages are selected. If True (default), raises
                 AllPagesRemovedError. If False, performs a no-op on the parent instead.
+            pdf_name (str | None): optional name for the child. Inherits parent's
+                pdf_name if not supplied.
 
         Returns:
             PdfExtract: a child instance containing the pages specified.
@@ -506,6 +549,7 @@ class PdfExtract:
         config_overrides: PyPdfToTextConfigOverrides | None = None,
         remove_from_parent: bool = False,
         raise_on_empty: bool = True,
+        pdf_name: str | None = None,
     ) -> PdfExtract:
         """
         Include pages between the supplied indices *inclusive*.
@@ -519,6 +563,8 @@ class PdfExtract:
             raise_on_empty (bool): When remove_from_parent=True, controls behavior if
                 all parent pages are selected. If True (default), raises
                 AllPagesRemovedError. If False, performs a no-op on the parent instead.
+            pdf_name (str | None): optional name for the child. Inherits parent's
+                pdf_name if not supplied.
 
         Returns:
             PdfExtract: a child instance containing the pages specified.
@@ -530,6 +576,7 @@ class PdfExtract:
         config_overrides: PyPdfToTextConfigOverrides | None = None,
         remove_from_parent: bool = False,
         raise_on_empty: bool = True,
+        pdf_name: str | None = None,
     ) -> PdfExtract | None:
         """
         Creates a child PdfExtract instance for the selected pages preserving
@@ -545,6 +592,8 @@ class PdfExtract:
                 all parent pages are selected. If True (default), raises
                 AllPagesRemovedError and leaves the parent unchanged. If False,
                 performs a no-op on the parent and logs a warning instead.
+            pdf_name (str | None): optional name for the child. Inherits parent's
+                pdf_name if not supplied.
 
         Returns:
             PdfExtract | None: a child instance containing the pages specified or
@@ -569,6 +618,7 @@ class PdfExtract:
         child_extract = PdfExtract(
             pdf=self.clip_pages(page_indices),
             config=PyPdfToTextConfig(base=self.config, overrides=config_overrides),
+            pdf_name=pdf_name or self.pdf_name,
             init_extracted_pages=[
                 pg for idx, pg in enumerate(self.extracted_pages) if idx in page_indices
             ],
@@ -608,7 +658,7 @@ class PdfExtract:
         if Image is None or ImageOps is None:
             raise ImportError("PIL not found. Run `pip install pypdftotext[image]`.")
         if self.compressed and not force:
-            logger.info("PdfExtract images are already compressed. No action taken.")
+            logger.info("[%s] Images already compressed. No action taken.", self.pdf_name)
             return  # we've already compressed these images
         for ip, page in enumerate(self.writer.pages):
             for ii, img in enumerate(page.images):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,3 +100,50 @@ class TestPyPdfToTextConfig:
 
         # Invalid field isn't set as attribute
         assert not hasattr(config, "INVALID_FIELD")
+
+
+class TestDictConfigShorthand:
+    """Test that PdfExtract and PdfExtractBatch accept a dict as the config parameter."""
+
+    @pytest.mark.unit
+    def test_pdf_extract_accepts_dict_config(self):
+        """PdfExtract(config={...}) builds a PyPdfToTextConfig from the dict."""
+        from pypdftotext import PdfExtract
+
+        extract = PdfExtract(pdf=b"%PDF-1.4 minimal", config={"DISABLE_OCR": True})
+        assert isinstance(extract.config, PyPdfToTextConfig)
+        assert extract.config.DISABLE_OCR is True
+
+    @pytest.mark.unit
+    def test_pdf_extract_dict_config_multiple_overrides(self):
+        """Multiple overrides in a dict are all applied."""
+        from pypdftotext import PdfExtract
+
+        extract = PdfExtract(
+            pdf=b"%PDF-1.4 minimal",
+            config={"DISABLE_OCR": True, "MIN_LINES_OCR_TRIGGER": 10},
+        )
+        assert extract.config.DISABLE_OCR is True
+        assert extract.config.MIN_LINES_OCR_TRIGGER == 10
+
+    @pytest.mark.unit
+    def test_pdf_extract_explicit_config_still_works(self):
+        """Existing PyPdfToTextConfig usage is unchanged (regression guard)."""
+        from pypdftotext import PdfExtract
+
+        config = PyPdfToTextConfig(overrides={"DISABLE_OCR": True})
+        extract = PdfExtract(pdf=b"%PDF-1.4 minimal", config=config)
+        assert extract.config is config
+        assert extract.config.DISABLE_OCR is True
+
+    @pytest.mark.unit
+    def test_pdf_extract_batch_accepts_dict_config(self):
+        """PdfExtractBatch(config={...}) propagates the built config."""
+        from pypdftotext import PdfExtractBatch
+
+        batch = PdfExtractBatch(
+            pdfs=[b"%PDF-1.4 minimal"],
+            config={"DISABLE_OCR": True},
+        )
+        assert isinstance(batch.config, PyPdfToTextConfig)
+        assert batch.config.DISABLE_OCR is True

--- a/tests/test_pdf_name.py
+++ b/tests/test_pdf_name.py
@@ -1,0 +1,182 @@
+"""Tests for the pdf_name attribute on PdfExtract."""
+
+import io
+import re
+import unittest
+import unittest.mock
+from pathlib import Path
+from unittest.mock import MagicMock, PropertyMock
+
+from pypdf import PdfReader
+
+from pypdftotext import PdfExtract
+from pypdftotext._config import PyPdfToTextConfig
+from pypdftotext.batch import PdfExtractBatch
+
+
+class TestPdfNameDerivation(unittest.TestCase):
+    """Test _derive_pdf_name across all input types."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.samples_dir = Path("samples")
+        cls.deid_epic_pdf = cls.samples_dir / "deid_epic.pdf"
+        if not cls.deid_epic_pdf.exists():
+            raise FileNotFoundError(f"Sample PDF not found: {cls.deid_epic_pdf}")
+        cls.pdf_bytes = cls.deid_epic_pdf.read_bytes()
+        cls.config = PyPdfToTextConfig(overrides={"DISABLE_OCR": True, "DISABLE_PROGRESS_BAR": True})
+
+    def test_explicit_name(self):
+        """Explicit pdf_name takes priority over all derivation."""
+        extract = PdfExtract(self.pdf_bytes, config=self.config, pdf_name="my_doc")
+        self.assertEqual(extract.pdf_name, "my_doc")
+
+    def test_str_file_path(self):
+        """String file path derives name from stem."""
+        extract = PdfExtract(str(self.deid_epic_pdf), config=self.config)
+        self.assertEqual(extract.pdf_name, "deid_epic")
+
+    def test_path_object(self):
+        """Path object derives name from stem."""
+        extract = PdfExtract(self.deid_epic_pdf, config=self.config)
+        self.assertEqual(extract.pdf_name, "deid_epic")
+
+    def test_bytes_input(self):
+        """Bytes input falls back to hash-based name."""
+        extract = PdfExtract(self.pdf_bytes, config=self.config)
+        self.assertRegex(extract.pdf_name, r"^pdf_[0-9a-f]{8}$")
+
+    def test_bytesio_input(self):
+        """BytesIO input falls back to hash-based name."""
+        extract = PdfExtract(io.BytesIO(self.pdf_bytes), config=self.config)
+        self.assertRegex(extract.pdf_name, r"^pdf_[0-9a-f]{8}$")
+
+    def test_bytes_hash_is_deterministic(self):
+        """Same bytes always produce the same hash-based name."""
+        ext1 = PdfExtract(self.pdf_bytes, config=self.config)
+        ext2 = PdfExtract(self.pdf_bytes, config=self.config)
+        self.assertEqual(ext1.pdf_name, ext2.pdf_name)
+
+    def test_pdfreader_with_title(self):
+        """PdfReader with metadata title uses that title."""
+        reader = PdfReader(io.BytesIO(self.pdf_bytes))
+        # Only test metadata path if the sample PDF has a title
+        extract = PdfExtract(reader, config=self.config)
+        if reader.metadata and reader.metadata.title:
+            self.assertEqual(extract.pdf_name, reader.metadata.title)
+        else:
+            self.assertRegex(extract.pdf_name, r"^pdf_[0-9a-f]{8}$")
+
+    def test_pdfreader_without_title(self):
+        """PdfReader without metadata title falls back to hash."""
+        reader = PdfReader(io.BytesIO(self.pdf_bytes))
+        with unittest.mock.patch.object(type(reader), "metadata", new_callable=PropertyMock) as m:
+            m.return_value = MagicMock(title=None)
+            extract = PdfExtract(reader, config=self.config)
+            self.assertRegex(extract.pdf_name, r"^pdf_[0-9a-f]{8}$")
+
+    def test_explicit_name_overrides_path(self):
+        """Explicit pdf_name overrides path-based derivation."""
+        extract = PdfExtract(str(self.deid_epic_pdf), config=self.config, pdf_name="override")
+        self.assertEqual(extract.pdf_name, "override")
+
+    def test_s3_uri_derives_stem(self):
+        """S3 URI string derives name from the object key stem."""
+        # Can't actually download from S3, but we can test the derivation
+        # by verifying the _derive_pdf_name method directly
+        extract = PdfExtract(self.pdf_bytes, config=self.config)
+        # Test the method directly with an S3-like string
+        name = extract._derive_pdf_name("s3://bucket/path/to/report.pdf", None)
+        self.assertEqual(name, "report")
+
+    def test_s3_uri_bucket_root_derives_bucket_name(self):
+        """S3 URI with just a bucket derives 'bucket' as the stem."""
+        extract = PdfExtract(self.pdf_bytes, config=self.config)
+        name = extract._derive_pdf_name("s3://bucket/", None)
+        self.assertEqual(name, "bucket")
+
+    def test_s3_uri_no_key_falls_back(self):
+        """S3 URI with no usable stem falls back to hash."""
+        extract = PdfExtract(self.pdf_bytes, config=self.config)
+        # PurePosixPath("s3://").stem gives "s3:" which is not empty,
+        # so this is actually a valid (if odd) name. Test the truly
+        # degenerate case where stem would be empty via direct method.
+        name = extract._derive_pdf_name("s3://", None)
+        # "s3:" is the stem — not empty, so it's used as-is
+        self.assertEqual(name, "s3:")
+
+
+class TestPdfNameChildPropagation(unittest.TestCase):
+    """Test pdf_name inheritance through child()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.samples_dir = Path("samples")
+        cls.deid_epic_pdf = cls.samples_dir / "deid_epic.pdf"
+        if not cls.deid_epic_pdf.exists():
+            raise FileNotFoundError(f"Sample PDF not found: {cls.deid_epic_pdf}")
+        cls.config = PyPdfToTextConfig(overrides={"DISABLE_OCR": True, "DISABLE_PROGRESS_BAR": True})
+
+    def test_child_inherits_parent_name(self):
+        """Child inherits parent's pdf_name by default."""
+        parent = PdfExtract(self.deid_epic_pdf, config=self.config, pdf_name="parent_doc")
+        child = parent.child([0])
+        self.assertEqual(child.pdf_name, "parent_doc")
+
+    def test_child_explicit_name_override(self):
+        """Child can override parent's pdf_name."""
+        parent = PdfExtract(self.deid_epic_pdf, config=self.config, pdf_name="parent_doc")
+        child = parent.child([0], pdf_name="child_doc")
+        self.assertEqual(child.pdf_name, "child_doc")
+
+    def test_child_callable_inherits_name(self):
+        """Child created via callable filter inherits parent's pdf_name."""
+        parent = PdfExtract(self.deid_epic_pdf, config=self.config, pdf_name="parent_doc")
+        child = parent.child(lambda pg: True)
+        self.assertIsNotNone(child)
+        self.assertEqual(child.pdf_name, "parent_doc")
+
+    def test_child_tuple_inherits_name(self):
+        """Child created via tuple range inherits parent's pdf_name."""
+        parent = PdfExtract(self.deid_epic_pdf, config=self.config, pdf_name="parent_doc")
+        child = parent.child((0, 0))
+        self.assertEqual(child.pdf_name, "parent_doc")
+
+
+class TestPdfNameBatchIntegration(unittest.TestCase):
+    """Test pdf_name integration with PdfExtractBatch."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.samples_dir = Path("samples")
+        cls.deid_epic_pdf = cls.samples_dir / "deid_epic.pdf"
+        if not cls.deid_epic_pdf.exists():
+            raise FileNotFoundError(f"Sample PDF not found: {cls.deid_epic_pdf}")
+        cls.pdf_bytes = cls.deid_epic_pdf.read_bytes()
+        cls.config = PyPdfToTextConfig(overrides={"DISABLE_OCR": True, "DISABLE_PROGRESS_BAR": True})
+
+    def test_dict_input_names_match_keys(self):
+        """Dict-based batch input: pdf_name matches dict keys."""
+        batch = PdfExtractBatch(
+            {"report_a": self.pdf_bytes, "report_b": self.pdf_bytes},
+            config=self.config,
+        )
+        self.assertEqual(batch.pdf_extracts["report_a"].pdf_name, "report_a")
+        self.assertEqual(batch.pdf_extracts["report_b"].pdf_name, "report_b")
+
+    def test_list_input_names_match_auto_keys(self):
+        """List-based batch input: pdf_name matches auto-generated keys."""
+        batch = PdfExtractBatch(
+            [self.pdf_bytes, self.pdf_bytes],
+            config=self.config,
+        )
+        self.assertEqual(batch.pdf_extracts["PDF[0]"].pdf_name, "PDF[0]")
+        self.assertEqual(batch.pdf_extracts["PDF[1]"].pdf_name, "PDF[1]")
+
+    def test_path_input_batch_uses_dict_key(self):
+        """Dict key overrides path-based derivation in batch."""
+        batch = PdfExtractBatch(
+            {"custom_name": self.deid_epic_pdf},
+            config=self.config,
+        )
+        self.assertEqual(batch.pdf_extracts["custom_name"].pdf_name, "custom_name")

--- a/tests/test_pdf_name.py
+++ b/tests/test_pdf_name.py
@@ -32,27 +32,27 @@ class TestPdfNameDerivation(unittest.TestCase):
         self.assertEqual(extract.pdf_name, "my_doc")
 
     def test_str_file_path(self):
-        """String file path derives name from stem."""
+        """String file path derives name from filename."""
         extract = PdfExtract(str(self.deid_epic_pdf), config=self.config)
-        self.assertEqual(extract.pdf_name, "deid_epic")
+        self.assertEqual(extract.pdf_name, "deid_epic.pdf")
 
     def test_path_object(self):
-        """Path object derives name from stem."""
+        """Path object derives name from filename."""
         extract = PdfExtract(self.deid_epic_pdf, config=self.config)
-        self.assertEqual(extract.pdf_name, "deid_epic")
+        self.assertEqual(extract.pdf_name, "deid_epic.pdf")
 
     def test_bytes_input(self):
-        """Bytes input falls back to hash-based name."""
+        """Bytes input falls back to hash-based filename."""
         extract = PdfExtract(self.pdf_bytes, config=self.config)
-        self.assertRegex(extract.pdf_name, r"^pdf_[0-9a-f]{8}$")
+        self.assertRegex(extract.pdf_name, r"^[0-9a-f]{8}\.pdf$")
 
     def test_bytesio_input(self):
-        """BytesIO input falls back to hash-based name."""
+        """BytesIO input falls back to hash-based filename."""
         extract = PdfExtract(io.BytesIO(self.pdf_bytes), config=self.config)
-        self.assertRegex(extract.pdf_name, r"^pdf_[0-9a-f]{8}$")
+        self.assertRegex(extract.pdf_name, r"^[0-9a-f]{8}\.pdf$")
 
     def test_bytes_hash_is_deterministic(self):
-        """Same bytes always produce the same hash-based name."""
+        """Same bytes always produce the same hash-based filename."""
         ext1 = PdfExtract(self.pdf_bytes, config=self.config)
         ext2 = PdfExtract(self.pdf_bytes, config=self.config)
         self.assertEqual(ext1.pdf_name, ext2.pdf_name)
@@ -65,45 +65,45 @@ class TestPdfNameDerivation(unittest.TestCase):
         if reader.metadata and reader.metadata.title:
             self.assertEqual(extract.pdf_name, reader.metadata.title)
         else:
-            self.assertRegex(extract.pdf_name, r"^pdf_[0-9a-f]{8}$")
+            self.assertRegex(extract.pdf_name, r"^[0-9a-f]{8}\.pdf$")
 
     def test_pdfreader_without_title(self):
-        """PdfReader without metadata title falls back to hash."""
+        """PdfReader without metadata title falls back to hash-based filename."""
         reader = PdfReader(io.BytesIO(self.pdf_bytes))
         with unittest.mock.patch.object(type(reader), "metadata", new_callable=PropertyMock) as m:
             m.return_value = MagicMock(title=None)
             extract = PdfExtract(reader, config=self.config)
-            self.assertRegex(extract.pdf_name, r"^pdf_[0-9a-f]{8}$")
+            self.assertRegex(extract.pdf_name, r"^[0-9a-f]{8}\.pdf$")
 
     def test_explicit_name_overrides_path(self):
         """Explicit pdf_name overrides path-based derivation."""
         extract = PdfExtract(str(self.deid_epic_pdf), config=self.config, pdf_name="override")
         self.assertEqual(extract.pdf_name, "override")
 
-    def test_s3_uri_derives_stem(self):
-        """S3 URI string derives name from the object key stem."""
-        # Can't actually download from S3, but we can test the derivation
-        # by verifying the _derive_pdf_name method directly
+    def test_s3_uri_derives_filename(self):
+        """S3 URI string derives name from the object key filename."""
         extract = PdfExtract(self.pdf_bytes, config=self.config)
-        # Test the method directly with an S3-like string
         name = extract._derive_pdf_name("s3://bucket/path/to/report.pdf", None)
-        self.assertEqual(name, "report")
+        self.assertEqual(name, "report.pdf")
 
-    def test_s3_uri_bucket_root_derives_bucket_name(self):
-        """S3 URI with just a bucket derives 'bucket' as the stem."""
+    def test_s3_uri_bucket_only(self):
+        """S3 URI with just a bucket and no object key derives 'bucket'."""
         extract = PdfExtract(self.pdf_bytes, config=self.config)
-        name = extract._derive_pdf_name("s3://bucket/", None)
+        name = extract._derive_pdf_name("s3://bucket", None)
         self.assertEqual(name, "bucket")
 
-    def test_s3_uri_no_key_falls_back(self):
-        """S3 URI with no usable stem falls back to hash."""
+    def test_s3_uri_bucket_root_falls_back(self):
+        """S3 URI with just a bucket and trailing slash falls back to hash."""
         extract = PdfExtract(self.pdf_bytes, config=self.config)
-        # PurePosixPath("s3://").stem gives "s3:" which is not empty,
-        # so this is actually a valid (if odd) name. Test the truly
-        # degenerate case where stem would be empty via direct method.
+        name = extract._derive_pdf_name("s3://bucket/", None)
+        # trailing slash means filename portion is empty — falls through to hash
+        self.assertRegex(name, r"^[0-9a-f]{8}\.pdf$")
+
+    def test_s3_uri_no_key_falls_back(self):
+        """S3 URI with no path falls back to hash."""
+        extract = PdfExtract(self.pdf_bytes, config=self.config)
         name = extract._derive_pdf_name("s3://", None)
-        # "s3:" is the stem — not empty, so it's used as-is
-        self.assertEqual(name, "s3:")
+        self.assertRegex(name, r"^[0-9a-f]{8}\.pdf$")
 
 
 class TestPdfNameChildPropagation(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **`PdfExtract.pdf_name`**: New keyword-only parameter and instance attribute that provides a human-readable identifier for each PDF, used in all log messages (e.g., `[quarterly-report] Sending pdf of 12345 bytes for OCR`). Auto-derived from input when not supplied: file path stem, PdfReader metadata title, or SHA-256 content hash fallback. Propagated through `child()` and `PdfExtractBatch`.
- **Dict config shorthand**: `PdfExtract` and `PdfExtractBatch` now accept a plain `dict` for the `config` parameter (e.g., `config={"DISABLE_OCR": True}`) as a convenience alternative to constructing a `PyPdfToTextConfig` explicitly.
- **Batch `pdf_name` propagation**: `PdfExtractBatch` now passes the batch key as `pdf_name` to each `PdfExtract` instance, improving log traceability in parallel/batch scenarios.
- **Improved log messages**: All key log statements in `PdfExtract` and `AzureDocIntelIntegrator` now include a `[pdf_name]` prefix for easier debugging.
- **Version bump**: `0.3.4` → `0.3.5`
- **README updates**: Added docs for `pdf_name`, dict config shorthand, `child()` options, `add_named_destinations()`, header/footer detection, and corrected `compress_images()` defaults.

## Test Coverage

- `tests/test_pdf_name.py` (new, 182 lines): Covers name derivation from all input types (path, bytes, BytesIO, PdfReader, S3 URI), explicit override, child propagation/override, and batch key propagation.
- `tests/test_config.py`: Added `TestDictConfigShorthand` class covering dict config for both `PdfExtract` and `PdfExtractBatch`.
