### PR TITLE
Skip image compression if an SMask is used

### DIFF
--- a/pypdftotext/__init__.py
+++ b/pypdftotext/__init__.py
@@ -1,6 +1,6 @@
 """Extract text from pdf pages from codebehind or Azure OCR as required"""
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 
 import io
 import logging

--- a/pypdftotext/pdf_extract.py
+++ b/pypdftotext/pdf_extract.py
@@ -634,6 +634,25 @@ class PdfExtract:
             self.remove_pages(page_indices, raise_on_empty=raise_on_empty)
         return child_extract
 
+    @staticmethod
+    def _page_has_smask(page: PageObject) -> bool:
+        """Return True if any /XObject referenced by the page has an /SMask entry.
+
+        Used by ``compress_images`` to skip pages where rewriting an image stream
+        would leave its soft mask referencing the old image dimensions/encoding.
+        """
+        rsrcs = page.get_inherited("/Resources", {})
+        if "/XObject" not in rsrcs:
+            return False
+        xobjs = rsrcs["/XObject"]
+        for name in xobjs:
+            obj = xobjs[name]
+            if isinstance(obj, NullObject):
+                continue
+            if "/SMask" in obj and not isinstance(obj["/SMask"], NullObject):
+                return True
+        return False
+
     def compress_images(
         self,
         white_point: int | None = None,
@@ -645,6 +664,11 @@ class PdfExtract:
         Reduces the size of the pdf by converting all images to grey scale and
         downsampling full page images more than 2x larger than the displayed
         area of the PDF.
+
+        Pages whose XObjects reference an /SMask (soft mask) are skipped with a
+        warning: rewriting the image stream via pypdf's ``img.replace`` does not
+        update the associated SMask, and the resulting dimension/encoding
+        mismatch can render previously legible regions as solid black.
 
         Args:
             white_point: pixel values greater than this are set to white (255) after
@@ -668,6 +692,14 @@ class PdfExtract:
             logger.info("[%s] Images already compressed. No action taken.", self.pdf_name)
             return  # we've already compressed these images
         for ip, page in enumerate(self.writer.pages):
+            if self._page_has_smask(page):
+                logger.warning(
+                    "[%s] Skipping image compression on pg_idx=%s: page references an "
+                    "image with /SMask (compressing risks redacted-looking output).",
+                    self.pdf_name,
+                    ip,
+                )
+                continue
             try:
                 for ii, img in enumerate(page.images):
                     if not isinstance(img.image, Image.Image):

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -625,6 +625,54 @@ class TestPdfExtract(unittest.TestCase):
             f"expected a jbig2dec DependencyError log, got: {logs.output}",
         )
 
+    def test_compress_images_skips_pages_with_smask(self):
+        """compress_images() skips whole pages whose XObjects carry an /SMask.
+
+        deid_epic.pdf has 51 soft-masked images on each of its 5 pages. Without
+        the skip, rewriting those image streams while leaving /SMask untouched
+        produces redacted-looking output (see PdfExtract._page_has_smask).
+        """
+        from PIL import Image
+
+        point_calls = []
+        original_point = Image.Image.point
+
+        def recording_point(self_img, lut, *args, **kwargs):
+            point_calls.append(lut)
+            return original_point(self_img, lut, *args, **kwargs)
+
+        pdf = PdfExtract(self.deid_epic_pdf)
+        page_count = len(pdf.extracted_pages)
+        self.assertGreater(page_count, 0)
+
+        with patch.object(Image.Image, "point", recording_point):
+            with self.assertLogs("pypdftotext.pdf_extract", level="WARNING") as logs:
+                pdf.compress_images()
+
+        # Every page is skipped before reaching the per-image processing loop,
+        # so PIL's per-pixel transform must never run.
+        self.assertEqual(len(point_calls), 0)
+
+        # One WARNING per skipped page; each names /SMask and the page index.
+        smask_warnings = [m for m in logs.output if "/SMask" in m]
+        self.assertEqual(len(smask_warnings), page_count)
+        for i in range(page_count):
+            self.assertTrue(
+                any(f"pg_idx={i}" in m for m in smask_warnings),
+                f"missing SMask skip warning for pg_idx={i}: {smask_warnings}",
+            )
+
+        # Flag still flips so subsequent calls short-circuit (matches JBIG2 contract).
+        self.assertTrue(pdf.compressed)
+
+    def test_page_has_smask_detects_xobject_smask(self):
+        """_page_has_smask returns True for pages with /SMask images, False otherwise."""
+        smask_pdf = PdfExtract(self.deid_epic_pdf)
+        self.assertTrue(PdfExtract._page_has_smask(smask_pdf.reader.pages[0]))
+
+        no_smask_pdf = PdfExtract(self.all70th_pdf)
+        self.assertFalse(PdfExtract._page_has_smask(no_smask_pdf.reader.pages[0]))
+
     def test_remove_pages_raises_by_default_when_all_removed(self):
         """remove_pages() raises AllPagesRemovedError when all pages are removed."""
         pdf = PdfExtract(self.deid_epic_pdf)


### PR DESCRIPTION
Skip image compression on any page with an SMask'd image to avoid 'redaction' style behaviors. Confirmed via local tests as all current samples contain protected health information.