### PR TITLE
OCR submit-and-await

### DIFF
--- a/docs/superpowers/plans/2026-05-13-ocr-submit-and-await.md
+++ b/docs/superpowers/plans/2026-05-13-ocr-submit-and-await.md
@@ -1,0 +1,2807 @@
+# OCR Submit-and-Await Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the session-scoped, blocking-poller OCR plumbing with a submit-and-await architecture backed by per-call `OCRResult` value objects. Fixes the silent-`None` timeout bug, eliminates cross-thread `AzureDocIntelIntegrator` state contamination (pattern P4), and removes one layer of threading from the batch path.
+
+**Architecture:** `AzureDocIntelIntegrator.last_result` (mutable session state) is replaced with `OCRResult` (an immutable per-call value type carrying the raw `AnalyzeResult`, rendered pages, and an optional error string). The integrator gains `submit()` (non-blocking) and `await_one()` (blocking, per-PDF) methods. A new module-level `await_all()` collectively waits on a dict of pollers, cancelling pending ones on timeout via a `CancellablePolling` subclass of `LROBasePolling`. The `AZURE_READ` singleton is promoted to a credential-cached shared client. Per-thread `last_result` access is preserved via `threading.local()` with `DeprecationWarning`. `PdfExtract` gains a public `ocr_result: OCRResult | None` attribute; `ExtractedPage` gains `ocr_error: str | None`. `PdfExtractBatch._perform_batch_ocr` drops its `ThreadPoolExecutor` in favor of submit-all-then-await-all.
+
+**Tech Stack:** Python 3.10+, `azure-ai-documentintelligence` SDK, `pypdf`, `tqdm`, `unittest.TestCase` + `unittest.mock`, `pytest` runner, `ruff`, `pyright`.
+
+**Reference spec:** [`docs/superpowers/specs/2026-05-13-ocr-submit-and-await-design.md`](../specs/2026-05-13-ocr-submit-and-await-design.md)
+
+**Python environment prefix:** All `python`, `pip`, `pytest`, `ruff`, and `pyright` commands must be prefixed with conda activation. Use Git Bash (not PowerShell) for these commands:
+
+```bash
+PREFIX="source /c/Users/samha/anaconda3/etc/profile.d/conda.sh && conda activate pypdftotext &&"
+```
+
+Throughout this plan, `<PREFIX>` refers to that string. Example: `<PREFIX> pytest tests/test_config.py -v`.
+
+---
+
+## File Structure
+
+**New files:**
+
+- `pypdftotext/ocr_result.py` — `OCRResult` dataclass with `succeeded` / `handwritten_ratio` / `rotation_degrees` / `page_at_index`
+- `pypdftotext/_cancellable_polling.py` — `CancellablePolling(LROBasePolling)` subclass (internal; underscore prefix)
+- `tests/test_azure_docintel_integrator.py` — submit / await_one / client_for / deprecation tests
+- `tests/test_cancellable_polling.py` — SDK canary
+- `tests/test_await_all.py` — collective-wait behavior tests
+
+**Modified files:**
+
+- `pypdftotext/azure_docintel_integrator.py` — adds submit / await_one / client_for / await_all / `_BUDGET_GRACE_SECONDS`; replaces `last_result` attribute with thread-local-backed deprecated property; deprecates `handwritten_ratio` / `rotation_degrees` / `page_at_index` / `reset`
+- `pypdftotext/extracted_page.py` — adds `ocr_error: str | None = None`
+- `pypdftotext/_config.py` — adds `AZURE_CLIENT_POOL_MAXSIZE: int = 20`
+- `pypdftotext/pdf_extract.py` — adds `ocr_result` attribute and `_apply_ocr_result()` method; rewrites `ocr()`; default `azure=AZURE_READ`; removes `self._azure.config = self.config` mutation
+- `pypdftotext/batch.py` — rewrites `_perform_batch_ocr` to use submit + await_all; removes OCR `ThreadPoolExecutor`
+- `pypdftotext/__init__.py` — adds `OCRResult` to imports and `__all__`
+
+**Unchanged:** `layout.py`, `header_footer_detection.py`, `page_fingerprint.py`, `tests/test_pdf_name.py`, `tests/test_docstrings.py` (will auto-pick-up new doctests).
+
+---
+
+## Tasks
+
+### Task 1: Add `AZURE_CLIENT_POOL_MAXSIZE` config field
+
+**Files:**
+
+- Modify: `pypdftotext/_config.py:13-50` (add to TypedDict) and `pypdftotext/_config.py:65-172` (add to dataclass)
+- Test: `tests/test_config.py` (extend existing)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_config.py`:
+
+```python
+def test_azure_client_pool_maxsize_default():
+    """AZURE_CLIENT_POOL_MAXSIZE defaults to 20."""
+    from pypdftotext import PyPdfToTextConfig
+    config = PyPdfToTextConfig()
+    assert config.AZURE_CLIENT_POOL_MAXSIZE == 20
+
+
+def test_azure_client_pool_maxsize_override():
+    """AZURE_CLIENT_POOL_MAXSIZE can be set via overrides."""
+    from pypdftotext import PyPdfToTextConfig
+    config = PyPdfToTextConfig(overrides={"AZURE_CLIENT_POOL_MAXSIZE": 50})
+    assert config.AZURE_CLIENT_POOL_MAXSIZE == 50
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+<PREFIX> pytest tests/test_config.py::test_azure_client_pool_maxsize_default tests/test_config.py::test_azure_client_pool_maxsize_override -v
+```
+
+Expected: FAIL with `AttributeError: 'PyPdfToTextConfig' object has no attribute 'AZURE_CLIENT_POOL_MAXSIZE'`.
+
+- [ ] **Step 3: Add field to TypedDict**
+
+In `pypdftotext/_config.py`, in the `PyPdfToTextConfigOverrides` TypedDict (around line 13-50), add:
+
+```python
+    AZURE_CLIENT_POOL_MAXSIZE: int
+```
+
+Place it alphabetically near the other `AZURE_*` fields.
+
+- [ ] **Step 4: Add field to dataclass with default and docstring**
+
+In `pypdftotext/_config.py`, in the `_ConfigMixIn` dataclass (around line 65+), after the existing `AZURE_DOCINTEL_MODEL` field, add:
+
+```python
+    AZURE_CLIENT_POOL_MAXSIZE: int = 20
+    """urllib3 connection pool size for the shared DocumentIntelligenceClient.
+    Default sized for MAX_WORKERS=10 with headroom. Increase if running batches
+    that submit more concurrent OCR requests than this value."""
+```
+
+- [ ] **Step 5: Run tests, verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_config.py -v
+```
+
+Expected: both new tests PASS; all existing tests in `test_config.py` continue to PASS.
+
+- [ ] **Step 6: Run lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/_config.py
+<PREFIX> ruff format --check pypdftotext/_config.py
+<PREFIX> pyright pypdftotext/_config.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pypdftotext/_config.py tests/test_config.py
+git commit -m "Add AZURE_CLIENT_POOL_MAXSIZE config field
+
+Sizes the urllib3 connection pool for the shared DocumentIntelligenceClient.
+Default 20, override via PyPdfToTextConfig.AZURE_CLIENT_POOL_MAXSIZE."
+```
+
+---
+
+### Task 2: Add `ocr_error` field to `ExtractedPage`
+
+**Files:**
+
+- Modify: `pypdftotext/extracted_page.py`
+- Test: `tests/test_pdf_extract.py` (extend existing)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_pdf_extract.py`:
+
+```python
+class TestExtractedPageOcrError(unittest.TestCase):
+    def test_ocr_error_defaults_to_none(self):
+        """ExtractedPage.ocr_error is None by default."""
+        from pypdf import PdfReader
+        from pypdftotext.extracted_page import ExtractedPage
+        # Use any page from any sample PDF; we don't need OCR to test the field.
+        # Construct a minimal mock PageObject via MagicMock.
+        from unittest.mock import MagicMock
+        page = ExtractedPage(page_obj=MagicMock(), handwritten_ratio=0.0, text="hello")
+        self.assertIsNone(page.ocr_error)
+
+    def test_ocr_error_can_be_set(self):
+        """ExtractedPage.ocr_error accepts string assignment."""
+        from unittest.mock import MagicMock
+        from pypdftotext.extracted_page import ExtractedPage
+        page = ExtractedPage(page_obj=MagicMock(), handwritten_ratio=0.0, text="")
+        page.ocr_error = "OCR timeout: simulated"
+        self.assertEqual(page.ocr_error, "OCR timeout: simulated")
+```
+
+If `tests/test_pdf_extract.py` doesn't already have a `unittest` import, add it. Check first.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+<PREFIX> pytest tests/test_pdf_extract.py::TestExtractedPageOcrError -v
+```
+
+Expected: FAIL with `TypeError: ExtractedPage.__init__() got an unexpected keyword argument 'ocr_error'` (if test_ocr_error_can_be_set is structured to construct with kwarg) OR `AttributeError: 'ExtractedPage' object has no attribute 'ocr_error'`.
+
+- [ ] **Step 3: Add field to ExtractedPage dataclass**
+
+In `pypdftotext/extracted_page.py`, in the `ExtractedPage` dataclass body (after `footer: str = ""` around line 47), add:
+
+```python
+    ocr_error: str | None = None
+    """Failure reason set when OCR was attempted and did not complete successfully.
+    None if OCR succeeded OR if OCR was never attempted for this page."""
+```
+
+Also update the class docstring's `Attributes:` section. Add a line after the `footer` attribute description:
+
+```
+        ocr_error: Failure reason set when OCR was attempted and failed. None
+            when OCR succeeded or was never attempted.
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_pdf_extract.py -v
+```
+
+Expected: new tests PASS; all existing tests in `test_pdf_extract.py` continue to PASS.
+
+- [ ] **Step 5: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/extracted_page.py
+<PREFIX> pyright pypdftotext/extracted_page.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pypdftotext/extracted_page.py tests/test_pdf_extract.py
+git commit -m "Add ExtractedPage.ocr_error field
+
+Carries a human-readable failure reason when OCR was attempted but did not
+complete successfully. None when OCR succeeded or was never attempted."
+```
+
+---
+
+### Task 3: Create `OCRResult` dataclass
+
+**Files:**
+
+- Create: `pypdftotext/ocr_result.py`
+- Test: `tests/test_pdf_extract.py` (extend) — full integrator tests come later
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_pdf_extract.py`:
+
+```python
+class TestOCRResult(unittest.TestCase):
+    def _fake_analyze_result_dict(self, num_pages=2):
+        """Build a minimal dict suitable for AnalyzeResult.__init__."""
+        return {
+            "apiVersion": "2024-11-30",
+            "modelId": "prebuilt-read",
+            "stringIndexType": "textElements",
+            "content": "page1 text\npage2 text",
+            "pages": [
+                {"pageNumber": i + 1, "angle": 0.0, "width": 8.5, "height": 11.0,
+                 "unit": "inch", "spans": [{"offset": i * 11, "length": 10}],
+                 "words": [], "lines": [], "selectionMarks": []}
+                for i in range(num_pages)
+            ],
+            "styles": [],
+        }
+
+    def test_succeeded_true_when_raw_has_pages_and_no_error(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        raw = AnalyzeResult(self._fake_analyze_result_dict(num_pages=1))
+        result = OCRResult(
+            pdf_name="x.pdf",
+            config=PyPdfToTextConfig(),
+            raw=raw,
+            pages=["page1 text"],
+        )
+        self.assertTrue(result.succeeded)
+        self.assertIsNone(result.error)
+
+    def test_succeeded_false_when_error_set(self):
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        result = OCRResult(
+            pdf_name="x.pdf",
+            config=PyPdfToTextConfig(),
+            raw=None,
+            pages=[],
+            error="OCR timeout: simulated",
+        )
+        self.assertFalse(result.succeeded)
+
+    def test_succeeded_false_when_raw_none(self):
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        result = OCRResult(pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=None, pages=[])
+        self.assertFalse(result.succeeded)
+
+    def test_page_at_index_returns_page_when_present(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        raw = AnalyzeResult(self._fake_analyze_result_dict(num_pages=2))
+        result = OCRResult(
+            pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=raw, pages=["a", "b"],
+        )
+        page = result.page_at_index(0)
+        self.assertIsNotNone(page)
+        self.assertEqual(page.page_number, 1)
+        page2 = result.page_at_index(1)
+        self.assertEqual(page2.page_number, 2)
+
+    def test_page_at_index_returns_none_when_missing(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        raw = AnalyzeResult(self._fake_analyze_result_dict(num_pages=1))
+        result = OCRResult(
+            pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=raw, pages=["a"],
+        )
+        self.assertIsNone(result.page_at_index(99))
+
+    def test_rotation_degrees_zero_when_page_missing(self):
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        result = OCRResult(pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=None, pages=[])
+        self.assertEqual(result.rotation_degrees(0), 0.0)
+
+    def test_handwritten_ratio_zero_when_no_styles(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        raw = AnalyzeResult(self._fake_analyze_result_dict(num_pages=1))
+        result = OCRResult(
+            pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=raw, pages=["a"],
+        )
+        self.assertEqual(result.handwritten_ratio(0), 0.0)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+<PREFIX> pytest tests/test_pdf_extract.py::TestOCRResult -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'pypdftotext.ocr_result'`.
+
+- [ ] **Step 3: Create `OCRResult`**
+
+Create `pypdftotext/ocr_result.py`:
+
+```python
+"""Per-OCR-call value type. Replaces session-scoped AzureDocIntelIntegrator.last_result."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from azure.ai.documentintelligence.models import AnalyzeResult, DocumentPage
+
+from ._config import PyPdfToTextConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OCRResult:
+    """Result of a single OCR call against Azure Document Intelligence.
+
+    Carries the rendered fixed-width page strings, the underlying SDK
+    ``AnalyzeResult`` (or ``None`` on hard failure), and an optional
+    human-readable error string. Replaces the session-scoped
+    ``AzureDocIntelIntegrator.last_result`` attribute, so two concurrent OCR
+    calls cannot alias each other's per-page metadata.
+
+    Attributes:
+        pdf_name: Identifier for the source PDF; useful for log correlation.
+        config: Snapshot of the PyPdfToTextConfig in effect when the OCR call
+            was submitted. Methods like handwritten_ratio read thresholds from
+            this snapshot rather than from any current global state.
+        raw: The underlying AnalyzeResult returned by the Azure SDK; None when
+            the operation failed before producing a result.
+        pages: One rendered fixed-width text string per page index submitted,
+            in submission order. Empty when the OCR call failed.
+        error: Human-readable failure description prefixed with ``OCR
+            <verb>:`` (e.g. ``"OCR timeout: ..."``). None when the call
+            succeeded.
+    """
+
+    pdf_name: str
+    config: PyPdfToTextConfig
+    raw: AnalyzeResult | None
+    pages: list[str] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """True iff no error was recorded and the SDK returned a result with at
+        least one page.
+
+        Example:
+            >>> from pypdftotext import PyPdfToTextConfig
+            >>> from pypdftotext.ocr_result import OCRResult
+            >>> OCRResult(pdf_name="x", config=PyPdfToTextConfig(), raw=None,
+            ...           pages=[], error="OCR timeout").succeeded
+            False
+            >>> OCRResult(pdf_name="x", config=PyPdfToTextConfig(), raw=None,
+            ...           pages=[]).succeeded
+            False
+        """
+        return (
+            self.error is None
+            and self.raw is not None
+            and bool(self.raw.pages)
+        )
+
+    def page_at_index(self, page_index: int) -> DocumentPage | None:
+        """Return the DocumentPage at the given 0-based index, or None.
+
+        Returns None when the OCR call failed OR when the index is out of
+        range relative to ``self.raw.pages``.
+
+        Example:
+            >>> from pypdftotext import PyPdfToTextConfig
+            >>> from pypdftotext.ocr_result import OCRResult
+            >>> OCRResult(pdf_name="x", config=PyPdfToTextConfig(), raw=None,
+            ...           pages=[]).page_at_index(0) is None
+            True
+        """
+        if self.raw is None or not self.raw.pages:
+            return None
+        for page in self.raw.pages:
+            if page.page_number == page_index + 1:
+                return page
+        return None
+
+    def rotation_degrees(self, page_index: int) -> float:
+        """Return Azure's reported rotation in degrees for the given page.
+
+        Returns 0.0 when the OCR call failed, the page is missing from the
+        result, or the reported angle is below
+        ``self.config.MIN_OCR_ROTATION_DEGREES``.
+        """
+        page = self.page_at_index(page_index)
+        if page is None:
+            return 0.0
+        angle = page.angle or 0.0
+        if abs(angle) > self.config.MIN_OCR_ROTATION_DEGREES:
+            return angle
+        return 0.0
+
+    def handwritten_ratio(self, page_index: int) -> float:
+        """Return the ratio of handwritten characters to total characters on
+        the given page (0.0 to 1.0).
+
+        Uses ``self.config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT`` as the minimum
+        confidence threshold for counting a span as handwritten. Returns 0.0
+        when the OCR call failed or the page has no text.
+        """
+        if self.raw is None:
+            return 0.0
+        page = self.page_at_index(page_index)
+        if page is None or not page.spans:
+            return 0.0
+        page_start = min(span.offset for span in page.spans)
+        page_end = max(span.offset + span.length for span in page.spans)
+        # Selection marks like :selected: and :unselected: are encoded in
+        # span offsets but not rendered; subtract their lengths.
+        length_reduction = sum(
+            sel.span.length for sel in (page.selection_marks or [])
+        )
+        # And subtract embedded newlines.
+        length_reduction += self.raw.content[page_start:page_end].count("\n")
+        page_length = page_end - page_start - length_reduction
+        if page_length <= 0:
+            logger.warning(
+                "Cannot compute handwritten ratio for page index %s: "
+                "length reduction (%s) >= span (%s, %s)",
+                page_index, length_reduction, page_start, page_end,
+            )
+            return 0.0
+        threshold = self.config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT
+        handwritten_length = sum(
+            min(span.length, page_end - span.offset)
+            for style in (self.raw.styles or [])
+            if style.is_handwritten and style.confidence >= threshold
+            for span in style.spans
+            if page_start <= span.offset < page_end
+        )
+        ratio = handwritten_length / page_length
+        return min(ratio, 1.0)
+```
+
+- [ ] **Step 4: Run unit tests to verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_pdf_extract.py::TestOCRResult -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Run doctests**
+
+```bash
+<PREFIX> pytest --doctest-modules pypdftotext/ocr_result.py -v
+```
+
+Expected: doctests PASS.
+
+- [ ] **Step 6: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/ocr_result.py
+<PREFIX> ruff format --check pypdftotext/ocr_result.py
+<PREFIX> pyright pypdftotext/ocr_result.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pypdftotext/ocr_result.py tests/test_pdf_extract.py
+git commit -m "Add OCRResult value type
+
+Immutable per-OCR-call result carrying the raw AnalyzeResult, rendered page
+strings, an optional error description, and helper methods (succeeded,
+page_at_index, rotation_degrees, handwritten_ratio) relocated from
+AzureDocIntelIntegrator. Replaces session-scoped last_result."
+```
+
+---
+
+### Task 4: Export `OCRResult` from the public package
+
+**Files:**
+
+- Modify: `pypdftotext/__init__.py`
+- Test: `tests/test_pdf_extract.py` (extend)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_pdf_extract.py` inside `TestOCRResult`:
+
+```python
+    def test_ocr_result_publicly_importable(self):
+        """OCRResult is importable from the top-level package."""
+        import pypdftotext
+        self.assertTrue(hasattr(pypdftotext, "OCRResult"))
+        from pypdftotext.ocr_result import OCRResult as _Direct
+        self.assertIs(pypdftotext.OCRResult, _Direct)
+        self.assertIn("OCRResult", pypdftotext.__all__)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+<PREFIX> pytest tests/test_pdf_extract.py::TestOCRResult::test_ocr_result_publicly_importable -v
+```
+
+Expected: FAIL — `OCRResult` not present on package.
+
+- [ ] **Step 3: Add import and `__all__` entry**
+
+In `pypdftotext/__init__.py`, add an import after the other internal imports (around line 16, after `from .pdf_extract import ...`):
+
+```python
+from .ocr_result import OCRResult
+```
+
+In the `__all__` list at the bottom (around line 101-113), add `"OCRResult"` alphabetically (between `"ExtractedPage"` and `"PyPdfToTextConfig"`):
+
+```python
+__all__ = [
+    "constants",
+    "layout",
+    "AZURE_READ",
+    "pdf_text_pages",
+    "pdf_text_page_lines",
+    "ExtractedPage",
+    "OCRResult",
+    "PyPdfToTextConfig",
+    "PyPdfToTextConfigOverrides",
+    "AllPagesRemovedError",
+    "PdfExtract",
+    "PdfExtractBatch",
+]
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+<PREFIX> pytest tests/test_pdf_extract.py::TestOCRResult -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Lint**
+
+```bash
+<PREFIX> ruff check pypdftotext/__init__.py
+<PREFIX> ruff format --check pypdftotext/__init__.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pypdftotext/__init__.py tests/test_pdf_extract.py
+git commit -m "Export OCRResult from pypdftotext top-level"
+```
+
+---
+
+### Task 5: Create `CancellablePolling` subclass
+
+**Files:**
+
+- Create: `pypdftotext/_cancellable_polling.py`
+- Create: `tests/test_cancellable_polling.py`
+
+- [ ] **Step 1: Write failing canary test**
+
+Create `tests/test_cancellable_polling.py`:
+
+```python
+"""SDK canary test: CancellablePolling depends on private LROBasePolling internals.
+
+If azure-core refactors `_delay`, `_extract_delay`, or `finished` in
+LROBasePolling, the construction or behavior here will fail loudly — that's
+the point. CI failure here means: go read the azure-core changelog.
+"""
+
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from pypdftotext._cancellable_polling import CancellablePolling
+
+
+class TestCancellablePolling(unittest.TestCase):
+    def _make_polling(self, lro_delay=0.05):
+        """Construct a CancellablePolling with a short polling interval.
+
+        We bypass `initialize()` (which needs a full pipeline response) by
+        injecting the attributes `_delay` reads directly. This keeps the test
+        focused on the cancel-event semantics rather than the SDK plumbing.
+        """
+        polling = CancellablePolling(lro_delay)
+        # Minimal scaffolding so _extract_delay/_extract_delay don't crash.
+        polling._timeout = lro_delay
+        polling._pipeline_response = MagicMock()
+        polling._pipeline_response.http_response.headers = {}
+        return polling
+
+    def test_cancel_event_terminates_polling(self):
+        """cancel_event.set() makes _delay return immediately AND finished()
+        return True."""
+        polling = self._make_polling(lro_delay=10.0)  # Would normally sleep 10s
+        # finished() should be False before cancel is set (super().finished()
+        # raises without an _operation; we override that).
+        self.assertFalse(polling.cancel_event.is_set())
+
+        # Cancel from a sidecar thread; main thread blocks in _delay.
+        def cancel_after():
+            time.sleep(0.05)
+            polling.cancel_event.set()
+        threading.Thread(target=cancel_after, daemon=True).start()
+
+        start = time.monotonic()
+        polling._delay()
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 0.5, "expected _delay to return within 500ms after cancel")
+        self.assertTrue(polling.finished())
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+<PREFIX> pytest tests/test_cancellable_polling.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'pypdftotext._cancellable_polling'`.
+
+- [ ] **Step 3: Create `CancellablePolling`**
+
+Create `pypdftotext/_cancellable_polling.py`:
+
+```python
+"""Internal subclass of LROBasePolling that supports cooperative cancellation.
+
+`LROPoller.result(timeout)` does not raise on timeout; it returns whatever
+`_polling_method.resource()` produces given the most recent polled response.
+That leaves the SDK's daemon polling thread running indefinitely, even when
+the caller no longer cares about the result.
+
+`CancellablePolling` adds a `cancel_event` Event. When set, the next call to
+`_delay()` returns immediately and `finished()` reports True, causing the
+polling loop in `LROBasePolling._poll()` to exit cleanly. The done callbacks
+then fire (possibly capturing a just-completed result; see await_one in
+azure_docintel_integrator), and the daemon thread terminates.
+
+Brittleness note: this subclass depends on the private `_delay`,
+`_extract_delay`, and `finished` methods of LROBasePolling. The test in
+tests/test_cancellable_polling.py is a canary that will fail loudly if those
+methods are refactored in a future azure-core version.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from azure.core.polling.base_polling import LROBasePolling
+
+
+class CancellablePolling(LROBasePolling):
+    """LROBasePolling with cooperative cancellation via a threading.Event."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cancel_event = threading.Event()
+
+    def _delay(self) -> None:
+        """Sleep for the inter-poll delay, returning immediately if cancelled.
+
+        Overrides ``LROBasePolling._delay``, which calls
+        ``self._transport.sleep(delay)`` unconditionally. ``Event.wait(timeout)``
+        gives us the same blocking behavior but returns early when the event is
+        set, enabling cancellation within milliseconds.
+        """
+        self.cancel_event.wait(self._extract_delay())
+
+    def finished(self) -> bool:
+        """True when cancelled OR when the polled operation reports done."""
+        if self.cancel_event.is_set():
+            return True
+        return super().finished()
+```
+
+- [ ] **Step 4: Run canary test, verify it passes**
+
+```bash
+<PREFIX> pytest tests/test_cancellable_polling.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/_cancellable_polling.py
+<PREFIX> ruff format --check pypdftotext/_cancellable_polling.py
+<PREFIX> pyright pypdftotext/_cancellable_polling.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pypdftotext/_cancellable_polling.py tests/test_cancellable_polling.py
+git commit -m "Add CancellablePolling for cooperative LRO cancellation
+
+LROBasePolling subclass with a cancel_event. When set, the next _delay()
+returns immediately and finished() reports True, causing the SDK's polling
+loop to exit cleanly. Tests serve as an SDK canary for the private methods
+we override."
+```
+
+---
+
+### Task 6: Add `client_for()` module helper with credential-keyed caching
+
+**Files:**
+
+- Modify: `pypdftotext/azure_docintel_integrator.py`
+- Create: `tests/test_azure_docintel_integrator.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/test_azure_docintel_integrator.py`:
+
+```python
+"""Tests for AzureDocIntelIntegrator and its module-level helpers."""
+
+import os
+import threading
+import unittest
+import warnings
+from unittest.mock import MagicMock, patch
+
+from pypdftotext import PyPdfToTextConfig
+from pypdftotext.azure_docintel_integrator import (
+    AzureDocIntelIntegrator,
+    AZURE_READ,
+    client_for,
+    _client_cache,
+    _client_cache_lock,
+)
+
+
+class TestClientFor(unittest.TestCase):
+    def setUp(self):
+        # Reset the cache between tests so they're hermetic.
+        with _client_cache_lock:
+            _client_cache.clear()
+
+    def _config_with_creds(self, endpoint, key, pool_maxsize=20):
+        return PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": endpoint,
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": key,
+            "AZURE_CLIENT_POOL_MAXSIZE": pool_maxsize,
+        })
+
+    def test_client_for(self):
+        """Parametrized: caching, missing creds, pool size kwarg."""
+        # Clear environment AZURE_* vars so config values take precedence.
+        with patch.dict(os.environ, {}, clear=False):
+            for var in ("AZURE_DOCINTEL_ENDPOINT", "AZURE_DOCINTEL_SUBSCRIPTION_KEY"):
+                os.environ.pop(var, None)
+
+            # 1. Missing creds → None.
+            self.assertIsNone(client_for(self._config_with_creds("", "")))
+            self.assertIsNone(client_for(self._config_with_creds("https://x.example", "")))
+            self.assertIsNone(client_for(self._config_with_creds("", "key123")))
+
+            # 2. Same (endpoint, key) → same client object.
+            cfg_a1 = self._config_with_creds("https://a.example", "key-a")
+            cfg_a2 = self._config_with_creds("https://a.example", "key-a")
+            client_a1 = client_for(cfg_a1)
+            client_a2 = client_for(cfg_a2)
+            self.assertIsNotNone(client_a1)
+            self.assertIs(client_a1, client_a2)
+
+            # 3. Different key → different client.
+            cfg_b = self._config_with_creds("https://a.example", "key-b")
+            client_b = client_for(cfg_b)
+            self.assertIsNot(client_a1, client_b)
+
+            # 4. Different endpoint → different client.
+            cfg_c = self._config_with_creds("https://c.example", "key-a")
+            client_c = client_for(cfg_c)
+            self.assertIsNot(client_a1, client_c)
+
+            # 5. Pool size kwarg forwarded.
+            cfg_pool = self._config_with_creds(
+                "https://pool.example", "key-pool", pool_maxsize=42,
+            )
+            # Patch the SDK constructor to capture the transport kwarg.
+            with patch(
+                "pypdftotext.azure_docintel_integrator.DocumentIntelligenceClient"
+            ) as mock_client_cls, patch(
+                "pypdftotext.azure_docintel_integrator.RequestsTransport"
+            ) as mock_transport_cls:
+                mock_transport_cls.return_value = MagicMock(name="transport")
+                mock_client_cls.return_value = MagicMock(name="client")
+                client_for(cfg_pool)
+                # RequestsTransport called with pool_maxsize=42.
+                kwargs = mock_transport_cls.call_args.kwargs
+                self.assertEqual(kwargs.get("connection_pool_maxsize"), 42)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'client_for' from 'pypdftotext.azure_docintel_integrator'`.
+
+- [ ] **Step 3: Add `client_for` and supporting state to the integrator module**
+
+In `pypdftotext/azure_docintel_integrator.py`, add these imports near the top (with the existing imports):
+
+```python
+import threading
+
+from azure.core.pipeline.transport import RequestsTransport
+```
+
+Then, immediately before the `@dataclass` declaration of `AzureDocIntelIntegrator` (around line 19), add:
+
+```python
+_client_cache: dict[tuple[str, str], DocumentIntelligenceClient] = {}
+"""Process-wide cache of DocumentIntelligenceClient instances keyed by
+(endpoint, key). Allows credential rotation between calls without leaking
+stale clients."""
+
+_client_cache_lock: threading.Lock = threading.Lock()
+"""Protects _client_cache against concurrent first-construction."""
+
+
+def client_for(config: PyPdfToTextConfig) -> DocumentIntelligenceClient | None:
+    """Return a DocumentIntelligenceClient for the given config's credentials.
+
+    Clients are cached by (endpoint, key) tuple, so rotating credentials
+    transparently produces a new client. The underlying urllib3 connection
+    pool size is taken from ``config.AZURE_CLIENT_POOL_MAXSIZE``.
+
+    Environment variables ``AZURE_DOCINTEL_ENDPOINT`` and
+    ``AZURE_DOCINTEL_SUBSCRIPTION_KEY`` take precedence over config fields,
+    matching the existing behavior of ``AzureDocIntelIntegrator.create_client``.
+
+    Returns:
+        A cached or newly-constructed client, or None if either endpoint or
+        key is missing.
+    """
+    endpoint = os.getenv("AZURE_DOCINTEL_ENDPOINT") or config.AZURE_DOCINTEL_ENDPOINT
+    key = (
+        os.getenv("AZURE_DOCINTEL_SUBSCRIPTION_KEY")
+        or config.AZURE_DOCINTEL_SUBSCRIPTION_KEY
+    )
+    if not endpoint or not key:
+        return None
+    cache_key = (endpoint, key)
+    with _client_cache_lock:
+        client = _client_cache.get(cache_key)
+        if client is None:
+            transport = RequestsTransport(
+                connection_pool_maxsize=config.AZURE_CLIENT_POOL_MAXSIZE,
+            )
+            client = DocumentIntelligenceClient(
+                endpoint, AzureKeyCredential(key), transport=transport,
+            )
+            _client_cache[cache_key] = client
+            logger.info(
+                "Cached new Azure OCR client: endpoint='%s', pool_maxsize=%s",
+                endpoint, config.AZURE_CLIENT_POOL_MAXSIZE,
+            )
+        return client
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/azure_docintel_integrator.py
+<PREFIX> ruff format --check pypdftotext/azure_docintel_integrator.py
+<PREFIX> pyright pypdftotext/azure_docintel_integrator.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pypdftotext/azure_docintel_integrator.py tests/test_azure_docintel_integrator.py
+git commit -m "Add client_for() module helper with credential-keyed cache
+
+Lazy-caches DocumentIntelligenceClient instances by (endpoint, key) so that
+credential rotation between calls transparently produces a new client. Pool
+size sourced from config.AZURE_CLIENT_POOL_MAXSIZE."
+```
+
+---
+
+### Task 7: Add `submit()` method to `AzureDocIntelIntegrator`
+
+**Files:**
+
+- Modify: `pypdftotext/azure_docintel_integrator.py`
+- Test: `tests/test_azure_docintel_integrator.py` (extend)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_azure_docintel_integrator.py`:
+
+```python
+class TestSubmit(unittest.TestCase):
+    def setUp(self):
+        with _client_cache_lock:
+            _client_cache.clear()
+
+    def test_submit_returns_poller_when_client_available(self):
+        """Happy path: submit returns a poller from the SDK."""
+        cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+        fake_poller = MagicMock(name="poller")
+        fake_client = MagicMock(name="client")
+        fake_client.begin_analyze_document.return_value = fake_poller
+        # Patch the env-var precedence path so config creds take effect.
+        with patch.dict(os.environ, {}, clear=False):
+            for var in ("AZURE_DOCINTEL_ENDPOINT", "AZURE_DOCINTEL_SUBSCRIPTION_KEY"):
+                os.environ.pop(var, None)
+            with patch(
+                "pypdftotext.azure_docintel_integrator.client_for",
+                return_value=fake_client,
+            ):
+                integrator = AzureDocIntelIntegrator(cfg)
+                poller = integrator.submit(b"pdfbytes", [0, 2], pdf_name="x.pdf")
+        self.assertIs(poller, fake_poller)
+        # Verify begin_analyze_document was invoked with the expected pages list
+        # (1-based, comma-joined) and the model from config.
+        kwargs = fake_client.begin_analyze_document.call_args.kwargs
+        self.assertEqual(kwargs["model_id"], cfg.AZURE_DOCINTEL_MODEL)
+        self.assertEqual(kwargs["pages"], "1,3")
+        # polling kwarg should be a CancellablePolling instance.
+        from pypdftotext._cancellable_polling import CancellablePolling
+        self.assertIsInstance(kwargs["polling"], CancellablePolling)
+
+    def test_submit_returns_none_when_no_client(self):
+        """No creds → submit returns None and logs an error."""
+        cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "",
+        })
+        with patch.dict(os.environ, {}, clear=False):
+            for var in ("AZURE_DOCINTEL_ENDPOINT", "AZURE_DOCINTEL_SUBSCRIPTION_KEY"):
+                os.environ.pop(var, None)
+            integrator = AzureDocIntelIntegrator(cfg)
+            with self.assertLogs(
+                "pypdftotext.azure_docintel_integrator", level="ERROR"
+            ) as captured:
+                result = integrator.submit(b"pdf", [0])
+        self.assertIsNone(result)
+        self.assertTrue(
+            any("no client" in line.lower() for line in captured.output),
+            f"expected 'no client' in logs; got {captured.output!r}",
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py::TestSubmit -v
+```
+
+Expected: FAIL with `AttributeError: 'AzureDocIntelIntegrator' object has no attribute 'submit'`.
+
+- [ ] **Step 3: Implement `submit()`**
+
+In `pypdftotext/azure_docintel_integrator.py`, add the following method to the `AzureDocIntelIntegrator` class (place it before `ocr_pages`):
+
+```python
+    def submit(
+        self,
+        pdf: bytes,
+        pages: list[int],
+        pdf_name: str = "",
+        *,
+        config: PyPdfToTextConfig | None = None,
+    ) -> AnalyzeDocumentLROPoller | None:
+        """Submit pages for OCR without blocking.
+
+        Returns a poller that can be passed to ``await_one`` (or collected in
+        a dict and passed to ``await_all``) for later result retrieval. Uses
+        ``CancellablePolling`` internally so the eventual wait can be
+        cancelled cleanly on timeout.
+
+        Args:
+            pdf: bytes of the PDF to OCR.
+            pages: 0-based page indices to OCR. Converted to the SDK's
+                1-based ``pages`` string parameter internally.
+            pdf_name: optional identifier for log correlation.
+            config: optional per-call override. Defaults to ``self.config``.
+
+        Returns:
+            A poller, or None when no client could be constructed (missing
+            credentials).
+        """
+        cfg = config or self.config
+        client = client_for(cfg)
+        if client is None:
+            logger.error(
+                "[%s] Cannot submit OCR: no client available "
+                "(check AZURE_DOCINTEL_ENDPOINT and AZURE_DOCINTEL_SUBSCRIPTION_KEY)",
+                pdf_name or "<unnamed>",
+            )
+            return None
+        prefix = f"[{pdf_name}] " if pdf_name else ""
+        logger.info(
+            "%sSubmitting %d pages for OCR (pdf bytes=%d)",
+            prefix, len(pages), len(pdf),
+        )
+        polling = CancellablePolling(client._config.polling_interval)
+        poller = client.begin_analyze_document(
+            model_id=cfg.AZURE_DOCINTEL_MODEL,
+            body=io.BytesIO(pdf),
+            pages=",".join(str(pg + 1) for pg in pages),
+            polling=polling,
+        )
+        return poller
+```
+
+Also add the import for `CancellablePolling` near the top of the file with the other internal imports:
+
+```python
+from ._cancellable_polling import CancellablePolling
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py::TestSubmit -v
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/azure_docintel_integrator.py
+<PREFIX> pyright pypdftotext/azure_docintel_integrator.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pypdftotext/azure_docintel_integrator.py tests/test_azure_docintel_integrator.py
+git commit -m "Add AzureDocIntelIntegrator.submit non-blocking method
+
+Returns an AnalyzeDocumentLROPoller backed by CancellablePolling. Accepts a
+per-call config override; uses client_for() for credential-keyed client
+caching."
+```
+
+---
+
+### Task 8: Add `await_one()` method to `AzureDocIntelIntegrator`
+
+**Files:**
+
+- Modify: `pypdftotext/azure_docintel_integrator.py`
+- Test: `tests/test_azure_docintel_integrator.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_azure_docintel_integrator.py`:
+
+```python
+class TestAwaitOne(unittest.TestCase):
+    def setUp(self):
+        with _client_cache_lock:
+            _client_cache.clear()
+        self.cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+            "AZURE_DOCINTEL_TIMEOUT": 30,
+        })
+
+    def _populated_analyze_result(self, num_pages=1):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        return AnalyzeResult({
+            "apiVersion": "2024-11-30",
+            "modelId": "prebuilt-read",
+            "stringIndexType": "textElements",
+            "content": " ".join(f"page{i+1}" for i in range(num_pages)),
+            "pages": [
+                {"pageNumber": i + 1, "angle": 0.0, "width": 8.5, "height": 11.0,
+                 "unit": "inch", "spans": [{"offset": i * 6, "length": 5}],
+                 "words": [], "lines": [], "selectionMarks": []}
+                for i in range(num_pages)
+            ],
+            "styles": [],
+        })
+
+    def test_await_one_success(self):
+        """Happy path: poller returns AnalyzeResult → OCRResult.succeeded."""
+        raw = self._populated_analyze_result(num_pages=2)
+        poller = MagicMock(name="poller")
+        poller.result.return_value = raw
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result = integrator.await_one(poller, pdf_name="x.pdf")
+        self.assertTrue(result.succeeded)
+        self.assertEqual(len(result.pages), 2)
+        self.assertIs(result.raw, raw)
+        self.assertIsNone(result.error)
+
+    def test_await_one_timeout_yields_error_result(self):
+        """REGRESSION: poller.result(timeout) returns None on timeout. Must
+        produce OCRResult(error="OCR timeout: ...") and not crash."""
+        poller = MagicMock(name="poller")
+        poller.result.return_value = None
+        # Provide a polling method so cancel_event.set() doesn't crash.
+        poller._polling_method = MagicMock()
+        poller._polling_method.cancel_event = threading.Event()
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result = integrator.await_one(poller, pdf_name="x.pdf")
+        self.assertFalse(result.succeeded)
+        self.assertIsNone(result.raw)
+        self.assertEqual(result.pages, [])
+        self.assertIsNotNone(result.error)
+        self.assertTrue(result.error.startswith("OCR timeout"))
+        # The cancel_event should have been set so the daemon poll thread can exit.
+        self.assertTrue(poller._polling_method.cancel_event.is_set())
+
+    def test_await_one_error_paths(self):
+        """Parametrized: HttpResponseError and empty-pages produce OCRResult.error."""
+        from azure.core.exceptions import HttpResponseError
+        integrator = AzureDocIntelIntegrator(self.cfg)
+
+        # 1. Poller raises HttpResponseError.
+        poller_http = MagicMock(name="poller_http")
+        poller_http.result.side_effect = HttpResponseError("server error")
+        poller_http._polling_method = MagicMock()
+        poller_http._polling_method.cancel_event = threading.Event()
+        result_http = integrator.await_one(poller_http, pdf_name="x.pdf")
+        self.assertFalse(result_http.succeeded)
+        self.assertTrue(result_http.error.startswith("OCR failed"))
+        self.assertIn("HttpResponseError", result_http.error)
+
+        # 2. AnalyzeResult with zero pages.
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        empty_result = AnalyzeResult({
+            "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+            "stringIndexType": "textElements", "content": "",
+            "pages": [], "styles": [],
+        })
+        poller_empty = MagicMock(name="poller_empty")
+        poller_empty.result.return_value = empty_result
+        result_empty = integrator.await_one(poller_empty, pdf_name="x.pdf")
+        self.assertFalse(result_empty.succeeded)
+        self.assertEqual(result_empty.error, "OCR failed: empty result (analyzeResult.pages was empty)")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py::TestAwaitOne -v
+```
+
+Expected: FAIL with `AttributeError: 'AzureDocIntelIntegrator' object has no attribute 'await_one'`.
+
+- [ ] **Step 3: Implement `await_one()`**
+
+In `pypdftotext/azure_docintel_integrator.py`, add these imports near the top:
+
+```python
+from azure.core.exceptions import AzureError, HttpResponseError
+
+from .ocr_result import OCRResult
+```
+
+Then add this method to `AzureDocIntelIntegrator`, immediately after `submit`:
+
+```python
+    def await_one(
+        self,
+        poller: AnalyzeDocumentLROPoller,
+        pdf_name: str = "",
+        *,
+        config: PyPdfToTextConfig | None = None,
+    ) -> OCRResult:
+        """Wait for the given poller to complete and build an OCRResult.
+
+        On timeout, the poller's CancellablePolling.cancel_event is set so
+        the SDK's daemon poll thread terminates cleanly. The returned
+        OCRResult carries error=str when the wait timed out, the SDK raised
+        an AzureError, or the result had zero pages.
+
+        Updates ``self._thread_local`` for deprecated callers of
+        ``self.last_result`` / ``self.handwritten_ratio`` / etc.
+
+        Args:
+            poller: poller previously returned by ``self.submit``.
+            pdf_name: identifier for log correlation; carried into the
+                returned OCRResult.
+            config: optional per-call override. Defaults to ``self.config``.
+
+        Returns:
+            An OCRResult. Never raises on Azure/timeout errors; check
+            ``result.succeeded`` and ``result.error``.
+        """
+        cfg = config or self.config
+        prefix = f"[{pdf_name}] " if pdf_name else ""
+        raw: AnalyzeResult | None
+        error: str | None = None
+        try:
+            raw = poller.result(cfg.AZURE_DOCINTEL_TIMEOUT)
+        except HttpResponseError as e:
+            raw = None
+            error = f"OCR failed: HttpResponseError: {e}"
+        except AzureError as e:
+            raw = None
+            error = f"OCR failed: {type(e).__name__}: {e}"
+        if raw is None and error is None:
+            # poller.result returned None — the timeout-without-exception case.
+            error = (
+                f"OCR timeout: poller returned no analyzeResult after "
+                f"{cfg.AZURE_DOCINTEL_TIMEOUT}s"
+            )
+        if error is not None:
+            # Signal the daemon poll thread to exit. Best-effort: not all
+            # mocked pollers have a CancellablePolling, so guard the access.
+            polling_method = getattr(poller, "_polling_method", None)
+            cancel_event = getattr(polling_method, "cancel_event", None)
+            if cancel_event is not None:
+                cancel_event.set()
+        pages: list[str] = []
+        if raw is not None and not raw.pages:
+            error = error or "OCR failed: empty result (analyzeResult.pages was empty)"
+        elif raw is not None:
+            pages = [layout.fixed_width_page(doc_page, cfg) for doc_page in raw.pages]
+        result = OCRResult(
+            pdf_name=pdf_name, config=cfg, raw=raw, pages=pages, error=error,
+        )
+        # Update thread-local for back-compat consumers.
+        self._thread_local.last_result = raw if raw is not None else AnalyzeResult({})
+        self._thread_local.ocr_result = result
+        if result.succeeded:
+            logger.info(
+                "%sOCR completed: %d pages rendered.", prefix, len(result.pages),
+            )
+        else:
+            logger.error("%sOCR did not complete: %s", prefix, result.error)
+        return result
+```
+
+Also add `_thread_local` as a dataclass field in `AzureDocIntelIntegrator`. Find the existing fields (around lines 25-27):
+
+```python
+    config: PyPdfToTextConfig = field(default_factory=PyPdfToTextConfig)
+    client: DocumentIntelligenceClient | None = field(default=None, init=False, repr=False)
+    last_result: AnalyzeResult = field(default_factory=lambda: AnalyzeResult({}), init=False)
+```
+
+Replace the `last_result` field declaration with `_thread_local`:
+
+```python
+    config: PyPdfToTextConfig = field(default_factory=PyPdfToTextConfig)
+    client: DocumentIntelligenceClient | None = field(default=None, init=False, repr=False)
+    _thread_local: threading.local = field(
+        default_factory=threading.local, init=False, repr=False,
+    )
+```
+
+This removes `last_result` as a dataclass field. Task 9 will re-add it as a deprecated @property.
+
+This change breaks references inside the existing `ocr_pages`, `handwritten_ratio`, `rotation_degrees`, `page_at_index` methods. **Patch those references now** so the module still imports:
+
+In `ocr_pages` (around line 89), replace:
+
+```python
+self.last_result = poller.result(self.config.AZURE_DOCINTEL_TIMEOUT)
+```
+
+with a temporary direct read of thread-local that we'll replace fully in Task 11:
+
+```python
+# (Temporary: Task 11 swaps ocr_pages to a thin wrapper around submit+await_one.)
+self._thread_local.last_result = poller.result(self.config.AZURE_DOCINTEL_TIMEOUT)
+```
+
+Then in the same method, replace every reference to `self.last_result` with `self._thread_local.last_result` (lines 94, 144, 163, 212 in the original; the line numbers shift after this edit, so search-and-replace within `ocr_pages` and the three downstream methods).
+
+Also update `reset()` (around line 57-59):
+
+```python
+    def reset(self):
+        """Clear last_result from previous run."""
+        self._thread_local.last_result = AnalyzeResult({})
+```
+
+Finally, in `pypdftotext/pdf_extract.py:355-358`, update the debug-write code that reads `azure.last_result.as_dict()` and `azure.last_result.content`:
+
+```python
+                (self.debug_path / "azure.json").write_text(
+                    json.dumps(azure._thread_local.last_result.as_dict(), indent=2),
+                    "utf-8",
+                )
+                (self.debug_path / "azure_content.txt").write_text(
+                    azure._thread_local.last_result.content or "",
+                    "utf-8",
+                )
+```
+
+These are temporary internal accesses; Task 12 replaces them with `extract.ocr_result.raw.as_dict()`.
+
+- [ ] **Step 4: Run all tests, verify nothing broke from the field swap**
+
+```bash
+<PREFIX> pytest tests/ -v
+```
+
+Expected:
+- The new `TestAwaitOne` tests PASS.
+- All existing tests (`test_batch.py`, `test_pdf_extract.py`, `test_config.py`, `test_pdf_name.py`) continue to PASS — they don't access `last_result` directly.
+
+If anything fails, the failure points to a missed internal reference. Use `<PREFIX> grep -n 'self\.last_result\|azure\.last_result' pypdftotext/*.py` (Git Bash) to find it. (Use the Grep tool in your editor for the same purpose.)
+
+- [ ] **Step 5: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/azure_docintel_integrator.py pypdftotext/pdf_extract.py
+<PREFIX> pyright pypdftotext/
+```
+
+Expected: no errors. `pyright` may complain that `AzureDocIntelIntegrator` has no `last_result` attribute (since we removed the field); ignore for now — Task 9 adds it back as a property.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pypdftotext/azure_docintel_integrator.py pypdftotext/pdf_extract.py tests/test_azure_docintel_integrator.py
+git commit -m "Add await_one method; move last_result to thread-local storage
+
+await_one wraps the blocking poller.result(timeout) call, catches AzureError
+and the silent-None timeout case, builds an OCRResult, signals
+CancellablePolling.cancel_event on failure, and updates _thread_local for
+back-compat callers. Internal references to self.last_result are routed
+through self._thread_local until Task 9 reintroduces the deprecated
+property."
+```
+
+---
+
+### Task 9: Reintroduce `last_result` as a deprecated property
+
+**Files:**
+
+- Modify: `pypdftotext/azure_docintel_integrator.py`
+- Test: `tests/test_azure_docintel_integrator.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_azure_docintel_integrator.py`:
+
+```python
+class TestDeprecatedSurface(unittest.TestCase):
+    def setUp(self):
+        with _client_cache_lock:
+            _client_cache.clear()
+        self.cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+
+    def _run_one_ocr(self, integrator):
+        """Helper: run a fake successful OCR so thread-local is populated."""
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        raw = AnalyzeResult({
+            "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+            "stringIndexType": "textElements", "content": "page1",
+            "pages": [{"pageNumber": 1, "angle": 0.0, "width": 8.5, "height": 11.0,
+                       "unit": "inch", "spans": [{"offset": 0, "length": 5}],
+                       "words": [], "lines": [], "selectionMarks": []}],
+            "styles": [],
+        })
+        poller = MagicMock()
+        poller.result.return_value = raw
+        return integrator.await_one(poller, pdf_name="x.pdf"), raw
+
+    def test_last_result_emits_deprecation_warning(self):
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        _, raw = self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            value = integrator.last_result
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(caught[0].category, DeprecationWarning)
+        self.assertIs(value, raw)
+
+    def test_last_result_default_when_no_ocr_on_thread(self):
+        """Accessing last_result before any OCR on this thread returns the
+        empty AnalyzeResult sentinel (back-compat with the original init)."""
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            value = integrator.last_result
+        self.assertIsInstance(value, AnalyzeResult)
+        self.assertIsNone(value.pages)  # AnalyzeResult({}).pages is None.
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py::TestDeprecatedSurface::test_last_result_emits_deprecation_warning tests/test_azure_docintel_integrator.py::TestDeprecatedSurface::test_last_result_default_when_no_ocr_on_thread -v
+```
+
+Expected: FAIL with `AttributeError: 'AzureDocIntelIntegrator' object has no attribute 'last_result'`.
+
+- [ ] **Step 3: Add the `last_result` deprecated property**
+
+In `pypdftotext/azure_docintel_integrator.py`, add `import warnings` at the top, then add this method to `AzureDocIntelIntegrator` (place it after `__post_init__`, before `create_client`):
+
+```python
+    @property
+    def last_result(self) -> AnalyzeResult:
+        """DEPRECATED. The raw AnalyzeResult from this thread's most recent
+        await_one call, or AnalyzeResult({}) if no OCR has run on this thread.
+
+        Replaced by ``PdfExtract.ocr_result.raw`` (or ``OCRResult.raw``).
+        Will be removed in a future minor release.
+        """
+        warnings.warn(
+            "AzureDocIntelIntegrator.last_result is deprecated and will be "
+            "removed in a future release. Use PdfExtract.ocr_result.raw or "
+            "OCRResult.raw instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(self._thread_local, "last_result", AnalyzeResult({}))
+```
+
+Now also update the temporary `self._thread_local.last_result = ...` reference inside `ocr_pages` to keep it untouched (Task 11 rewrites `ocr_pages`); and any debug-path internal accesses you added in Task 8 to `pypdftotext/pdf_extract.py:355-358` stay routed through `_thread_local` (still internal, no warning).
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py::TestDeprecatedSurface -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify existing tests still pass**
+
+```bash
+<PREFIX> pytest tests/ -v
+```
+
+Expected: all PASS. No existing test should be reading `azure.last_result` (which would now emit a DeprecationWarning that propagates in test output but doesn't fail).
+
+- [ ] **Step 6: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/azure_docintel_integrator.py
+<PREFIX> pyright pypdftotext/azure_docintel_integrator.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pypdftotext/azure_docintel_integrator.py tests/test_azure_docintel_integrator.py
+git commit -m "Reintroduce last_result as deprecated thread-local property
+
+Thread-local-backed @property emits DeprecationWarning. Each thread sees
+its own most-recent OCR result, strictly improving on the pre-rewrite race
+where multiple PdfExtracts sharing one integrator clobbered each other."
+```
+
+---
+
+### Task 10: Deprecate `handwritten_ratio` / `rotation_degrees` / `page_at_index` / `reset` on integrator
+
+**Files:**
+
+- Modify: `pypdftotext/azure_docintel_integrator.py`
+- Test: `tests/test_azure_docintel_integrator.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `TestDeprecatedSurface` in `tests/test_azure_docintel_integrator.py`:
+
+```python
+    def test_handwritten_ratio_back_compat(self):
+        """Deprecated wrapper returns the same value as OCRResult.handwritten_ratio."""
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result, _ = self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            integrator_value = integrator.handwritten_ratio(0)
+        # Warning emitted.
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(caught[0].category, DeprecationWarning)
+        # Value matches OCRResult.
+        self.assertEqual(integrator_value, result.handwritten_ratio(0))
+
+    def test_rotation_degrees_back_compat(self):
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result, _ = self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self.assertEqual(integrator.rotation_degrees(0), result.rotation_degrees(0))
+        self.assertEqual(caught[0].category, DeprecationWarning)
+
+    def test_page_at_index_back_compat(self):
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result, _ = self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self.assertIs(integrator.page_at_index(0), result.page_at_index(0))
+        self.assertEqual(caught[0].category, DeprecationWarning)
+
+    def test_reset_clears_thread_local_with_warning(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            integrator.reset()
+        self.assertEqual(caught[0].category, DeprecationWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            self.assertIsNone(integrator.last_result.pages)  # back to empty sentinel
+```
+
+Also add a thread-isolation test (this is the P4 regression test):
+
+```python
+class TestThreadLocalIsolation(unittest.TestCase):
+    def setUp(self):
+        with _client_cache_lock:
+            _client_cache.clear()
+
+    def test_thread_local_isolation_across_threads(self):
+        """REGRESSION (P4): two threads sharing one integrator each see their
+        own most-recent OCR result, not each other's."""
+        from azure.ai.documentintelligence.models import AnalyzeResult
+
+        def make_raw(label):
+            return AnalyzeResult({
+                "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+                "stringIndexType": "textElements", "content": label,
+                "pages": [{"pageNumber": 1, "angle": 0.0, "width": 8.5,
+                           "height": 11.0, "unit": "inch",
+                           "spans": [{"offset": 0, "length": len(label)}],
+                           "words": [], "lines": [], "selectionMarks": []}],
+                "styles": [],
+            })
+
+        cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+        integrator = AzureDocIntelIntegrator(cfg)
+        results = {}
+
+        def worker(label):
+            poller = MagicMock()
+            poller.result.return_value = make_raw(label)
+            integrator.await_one(poller, pdf_name=label)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                results[label] = integrator.last_result.content
+
+        threads = [
+            threading.Thread(target=worker, args=("alpha",)),
+            threading.Thread(target=worker, args=("bravo",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Each thread saw its own label, not the other's.
+        self.assertEqual(results["alpha"], "alpha")
+        self.assertEqual(results["bravo"], "bravo")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py::TestDeprecatedSurface tests/test_azure_docintel_integrator.py::TestThreadLocalIsolation -v
+```
+
+Expected: `TestThreadLocalIsolation` likely PASSES already (thread-local is in place). `TestDeprecatedSurface::test_*_back_compat` and `test_reset_clears_thread_local_with_warning` FAIL because the existing integrator methods don't emit warnings yet (and `page_at_index` may return None when reading from the thread-local instead of the field).
+
+- [ ] **Step 3: Replace the integrator's `handwritten_ratio` / `rotation_degrees` / `page_at_index` / `reset` with deprecated wrappers**
+
+In `pypdftotext/azure_docintel_integrator.py`, replace the existing implementations of these four methods with thin wrappers that delegate to `OCRResult` via thread-local:
+
+```python
+    def reset(self):
+        """DEPRECATED. Clear the thread-local last_result.
+
+        Replaced by allowing OCRResult instances to manage their own
+        lifetime; no explicit reset is needed in the new API.
+        """
+        warnings.warn(
+            "AzureDocIntelIntegrator.reset is deprecated; OCRResult instances "
+            "manage their own lifetime. This call clears the thread-local "
+            "back-compat slot.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._thread_local.last_result = AnalyzeResult({})
+        self._thread_local.ocr_result = None
+
+    def handwritten_ratio(
+        self,
+        page_index: int,
+        handwritten_confidence_limit: float | None = None,
+    ) -> float:
+        """DEPRECATED. Returns the handwritten ratio for the given page from
+        this thread's most-recent OCR result.
+
+        Replaced by ``OCRResult.handwritten_ratio(page_index)`` (or
+        ``PdfExtract.ocr_result.handwritten_ratio(page_index)``).
+        """
+        warnings.warn(
+            "AzureDocIntelIntegrator.handwritten_ratio is deprecated. Use "
+            "OCRResult.handwritten_ratio (e.g. via PdfExtract.ocr_result) "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if handwritten_confidence_limit is not None:
+            logger.warning(
+                "handwritten_confidence_limit arg is no longer supported; "
+                "set config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT instead. "
+                "(requested=%.2f, effective=%.2f)",
+                handwritten_confidence_limit,
+                self.config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT,
+            )
+        result = getattr(self._thread_local, "ocr_result", None)
+        return result.handwritten_ratio(page_index) if result is not None else 0.0
+
+    def rotation_degrees(self, page_index: int) -> float:
+        """DEPRECATED. See OCRResult.rotation_degrees."""
+        warnings.warn(
+            "AzureDocIntelIntegrator.rotation_degrees is deprecated. Use "
+            "OCRResult.rotation_degrees (e.g. via PdfExtract.ocr_result) "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        result = getattr(self._thread_local, "ocr_result", None)
+        return result.rotation_degrees(page_index) if result is not None else 0.0
+
+    def page_at_index(self, page_index: int) -> DocumentPage | None:
+        """DEPRECATED. See OCRResult.page_at_index."""
+        warnings.warn(
+            "AzureDocIntelIntegrator.page_at_index is deprecated. Use "
+            "OCRResult.page_at_index (e.g. via PdfExtract.ocr_result) "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        result = getattr(self._thread_local, "ocr_result", None)
+        return result.page_at_index(page_index) if result is not None else None
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py -v
+```
+
+Expected: all PASS, including `TestDeprecatedSurface` and `TestThreadLocalIsolation`.
+
+- [ ] **Step 5: Run the whole suite to verify nothing else regresses**
+
+```bash
+<PREFIX> pytest tests/ -v
+```
+
+Expected: all PASS. Existing callers in `pdf_extract.py:373, 387, 388` invoke the integrator's deprecated methods (still functional, but will emit DeprecationWarnings during test runs). Task 12 routes those calls through `OCRResult` instead.
+
+- [ ] **Step 6: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/azure_docintel_integrator.py
+<PREFIX> pyright pypdftotext/azure_docintel_integrator.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pypdftotext/azure_docintel_integrator.py tests/test_azure_docintel_integrator.py
+git commit -m "Deprecate integrator handwritten_ratio/rotation_degrees/page_at_index/reset
+
+Thin wrappers that read this thread's most-recent OCRResult from
+_thread_local and delegate. Each emits DeprecationWarning pointing at the
+OCRResult replacement. P4 cross-thread contamination regression test
+included."
+```
+
+---
+
+### Task 11: Convert `ocr_pages()` to a thin wrapper
+
+**Files:**
+
+- Modify: `pypdftotext/azure_docintel_integrator.py`
+- Test: existing `tests/test_batch.py` / `tests/test_pdf_extract.py` continue to exercise this path
+
+- [ ] **Step 1: Replace `ocr_pages` body**
+
+In `pypdftotext/azure_docintel_integrator.py`, replace the entire `ocr_pages` method body with:
+
+```python
+    def ocr_pages(
+        self, pdf: bytes, pages: list[int], pdf_name: str = "",
+    ) -> list[str]:
+        """Submit pages for OCR and wait for the result.
+
+        Thin wrapper over ``submit`` + ``await_one``. Returns the rendered
+        fixed-width page strings, or an empty list on failure (failure is
+        also logged at ERROR; see ``await_one`` for details).
+        """
+        if self.config.AZURE_DOCINTEL_AUTO_CLIENT and self.client is None:
+            # Eager create-and-cache via client_for so the legacy `self.client`
+            # attribute is populated for any external introspection.
+            self.client = client_for(self.config)
+        poller = self.submit(pdf, pages, pdf_name=pdf_name)
+        if poller is None:
+            return []
+        result = self.await_one(poller, pdf_name=pdf_name)
+        return result.pages
+```
+
+Remove `create_client()`'s body and have it delegate to `client_for()` for back-compat:
+
+```python
+    def create_client(self) -> bool:
+        """Create or retrieve the cached DocumentIntelligenceClient.
+
+        Returns True if a client is available (newly cached or pre-existing),
+        False otherwise. The actual client object is stored on
+        ``self.client`` for back-compat with any callers that introspect it.
+        """
+        self.client = client_for(self.config)
+        if self.client is None:
+            endpoint = (
+                os.getenv("AZURE_DOCINTEL_ENDPOINT") or self.config.AZURE_DOCINTEL_ENDPOINT
+            )
+            logger.error("Failed to obtain Azure OCR Client at endpoint='%s'", endpoint)
+            return False
+        return True
+```
+
+- [ ] **Step 2: Run the full suite**
+
+```bash
+<PREFIX> pytest tests/ -v
+```
+
+Expected: all PASS. The existing test_batch.py and test_pdf_extract.py exercise `ocr_pages` indirectly through `PdfExtract.ocr` and `PdfExtractBatch._perform_batch_ocr`. They should still pass — output equality should be preserved because `await_one` builds `pages` via the same `layout.fixed_width_page` calls.
+
+If a test fails, the most likely cause is the `tqdm` progress bar that previously wrapped the page iteration. The new `await_one` does not emit a per-page progress bar. If existing tests assert on progress-bar output (unlikely), reconcile by either keeping the old progress bar in `ocr_pages` (wrap the `result.pages` build) or updating the test.
+
+- [ ] **Step 3: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/azure_docintel_integrator.py
+<PREFIX> pyright pypdftotext/azure_docintel_integrator.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pypdftotext/azure_docintel_integrator.py
+git commit -m "Convert ocr_pages to a thin wrapper over submit + await_one
+
+Legacy callers see identical behavior — same signature, same return shape,
+same logged events on success. Failures now log at ERROR and return an
+empty list instead of raising AttributeError on a None last_result."
+```
+
+---
+
+### Task 12: Add `_BUDGET_GRACE_SECONDS` constant and `await_all()` helper
+
+**Files:**
+
+- Modify: `pypdftotext/azure_docintel_integrator.py`
+- Create: `tests/test_await_all.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_await_all.py`:
+
+```python
+"""Tests for the module-level await_all collective wait helper."""
+
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from pypdftotext import PyPdfToTextConfig
+from pypdftotext.azure_docintel_integrator import (
+    AzureDocIntelIntegrator,
+    await_all,
+    _BUDGET_GRACE_SECONDS,
+)
+
+
+def _fake_poller(immediate_result=None, raises=None):
+    """Build a mocked poller whose done callback fires when .result() is
+    called the way await_one calls it. We simulate the SDK's callback
+    semantics by invoking registered callbacks during result()."""
+    poller = MagicMock()
+    callbacks = []
+    poller.add_done_callback.side_effect = lambda fn: callbacks.append(fn)
+    if raises is not None:
+        def _raises(*args, **kwargs):
+            for cb in callbacks:
+                cb(poller)
+            raise raises
+        poller.result.side_effect = _raises
+    else:
+        def _returns(*args, **kwargs):
+            for cb in callbacks:
+                cb(poller)
+            return immediate_result
+        poller.result.side_effect = _returns
+    poller._polling_method = MagicMock()
+    poller._polling_method.cancel_event = threading.Event()
+    return poller
+
+
+def _make_analyze_result(label):
+    from azure.ai.documentintelligence.models import AnalyzeResult
+    return AnalyzeResult({
+        "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+        "stringIndexType": "textElements", "content": label,
+        "pages": [{"pageNumber": 1, "angle": 0.0, "width": 8.5, "height": 11.0,
+                   "unit": "inch", "spans": [{"offset": 0, "length": len(label)}],
+                   "words": [], "lines": [], "selectionMarks": []}],
+        "styles": [],
+    })
+
+
+class TestAwaitAll(unittest.TestCase):
+    def setUp(self):
+        self.cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+        self.integrator = AzureDocIntelIntegrator(self.cfg)
+
+    def test_await_all_collects_all_results(self):
+        """N=0, N=1, N=3 all return well-formed dicts."""
+        for size in (0, 1, 3):
+            with self.subTest(size=size):
+                pollers = {
+                    f"pdf{i}": _fake_poller(immediate_result=_make_analyze_result(f"pdf{i}"))
+                    for i in range(size)
+                }
+                results = await_all(
+                    pollers, self.integrator, timeout=5.0, config=self.cfg,
+                )
+                self.assertEqual(len(results), size)
+                for name in pollers:
+                    self.assertTrue(results[name].succeeded)
+
+    def test_await_all_synthesizes_budget_exceeded_on_timeout(self):
+        """Pollers that don't complete by the budget get synthesized error
+        results; a poller that completes during the grace window wins."""
+        from azure.ai.documentintelligence.models import AnalyzeResult
+
+        # Poller A completes immediately.
+        poller_a = _fake_poller(immediate_result=_make_analyze_result("alpha"))
+
+        # Poller B blocks indefinitely (simulates "still polling Azure").
+        poller_b = MagicMock()
+        b_callbacks = []
+        poller_b.add_done_callback.side_effect = lambda fn: b_callbacks.append(fn)
+        b_block = threading.Event()
+
+        def _b_result(timeout=None):
+            b_block.wait(timeout)
+            # When cancel event is set, return None (simulating SDK behavior).
+            return None
+        poller_b.result.side_effect = _b_result
+        poller_b._polling_method = MagicMock()
+        poller_b._polling_method.cancel_event = threading.Event()
+
+        pollers = {"alpha": poller_a, "bravo": poller_b}
+        # Use a short budget so timeout fires fast.
+        results = await_all(pollers, self.integrator, timeout=0.5, config=self.cfg)
+
+        self.assertTrue(results["alpha"].succeeded)
+        self.assertFalse(results["bravo"].succeeded)
+        self.assertTrue(results["bravo"].error.startswith("OCR batch budget exceeded"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+<PREFIX> pytest tests/test_await_all.py -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'await_all'`.
+
+- [ ] **Step 3: Implement `_BUDGET_GRACE_SECONDS` and `await_all`**
+
+In `pypdftotext/azure_docintel_integrator.py`, near `client_for`, add:
+
+```python
+_BUDGET_GRACE_SECONDS: float = 5.0
+"""How long await_all waits after signalling cancellation for late callbacks
+to fire before synthesizing 'budget exceeded' results. Internal tuning
+constant; not configurable."""
+
+
+def await_all(
+    pollers: "Mapping[str, AnalyzeDocumentLROPoller]",
+    integrator: "AzureDocIntelIntegrator",
+    timeout: float | None,
+    *,
+    config: PyPdfToTextConfig | None = None,
+) -> dict[str, OCRResult]:
+    """Collectively wait for many pollers and return one OCRResult per name.
+
+    Phase 1: register a done callback on each poller. The callback builds
+    an OCRResult via ``integrator.await_one`` (which returns near-instantly
+    when called from inside the callback because the poller is already
+    done) and records it in a shared results dict.
+
+    Phase 2: block until either all callbacks have fired or the overall
+    ``timeout`` elapses.
+
+    Phase 3 (on timeout): set ``cancel_event`` on every poller whose result
+    is still missing. The SDK's daemon poll loop exits within milliseconds
+    and the callback fires (possibly capturing a lucky-race late result).
+    Wait up to ``_BUDGET_GRACE_SECONDS`` for these late callbacks.
+
+    Phase 4: synthesize ``OCRResult(error="OCR batch budget exceeded ...")``
+    for any name still missing.
+
+    Args:
+        pollers: dict mapping pdf_name to poller.
+        integrator: the integrator whose await_one is used. Its
+            ``_thread_local`` is updated for the LAST callback to fire (race
+            outcome; matches today's "undefined in batch context" semantics
+            for AZURE_READ.last_result).
+        timeout: overall budget in seconds. None means wait indefinitely.
+        config: optional per-batch config override for ``await_one``.
+
+    Returns:
+        dict mapping pdf_name to OCRResult. Never raises.
+    """
+    cfg = config or integrator.config
+    results: dict[str, OCRResult] = {}
+    done_event = threading.Event()
+    lock = threading.Lock()
+    total = len(pollers)
+    if total == 0:
+        return results
+
+    def _on_done(name: str, poller) -> None:
+        # poller.result(small_timeout) is safe here because the poller is
+        # done. We pass a tiny timeout so a bug in our callback path can't
+        # hang forever.
+        result = integrator.await_one(poller, pdf_name=name, config=cfg)
+        with lock:
+            if name not in results:
+                results[name] = result
+                if len(results) == total:
+                    done_event.set()
+
+    for name, poller in pollers.items():
+        # Capture name via default arg to avoid late-binding closure bug.
+        poller.add_done_callback(lambda p, n=name: _on_done(n, p))
+
+    if not done_event.wait(timeout):
+        # Budget elapsed. Cancel pending pollers and wait briefly for late
+        # callbacks (lucky-race window).
+        pending_names = [n for n in pollers if n not in results]
+        for n in pending_names:
+            polling_method = getattr(pollers[n], "_polling_method", None)
+            cancel_event = getattr(polling_method, "cancel_event", None)
+            if cancel_event is not None:
+                cancel_event.set()
+        done_event.wait(_BUDGET_GRACE_SECONDS)
+        # Synthesize errors for any still missing.
+        with lock:
+            for n in pollers:
+                if n not in results:
+                    results[n] = OCRResult(
+                        pdf_name=n, config=cfg, raw=None, pages=[],
+                        error=(
+                            f"OCR batch budget exceeded after {timeout}s "
+                            f"(pdf still pending)"
+                        ),
+                    )
+    return results
+```
+
+Also add to the imports near the top of the file:
+
+```python
+from collections.abc import Mapping
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_await_all.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/azure_docintel_integrator.py
+<PREFIX> pyright pypdftotext/azure_docintel_integrator.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pypdftotext/azure_docintel_integrator.py tests/test_await_all.py
+git commit -m "Add await_all collective wait with cooperative cancellation
+
+Registers done callbacks on each poller, blocks until all complete or the
+budget elapses. On budget exceeded, sets cancel_event on pending pollers,
+waits _BUDGET_GRACE_SECONDS for late callbacks, then synthesizes 'OCR
+batch budget exceeded' OCRResults for any still missing."
+```
+
+---
+
+### Task 13: Add `PdfExtract.ocr_result` + `_apply_ocr_result()`; rewrite `ocr()`
+
+**Files:**
+
+- Modify: `pypdftotext/pdf_extract.py`
+- Test: `tests/test_pdf_extract.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_pdf_extract.py`:
+
+```python
+class TestOcrEndToEnd(unittest.TestCase):
+    """Coverage-based: success, timeout, azure-error variants of PdfExtract.ocr."""
+
+    def setUp(self):
+        from pathlib import Path
+        self.samples_dir = Path("samples")
+        self.pdf_path = self.samples_dir / "all70th.pdf"
+        if not self.pdf_path.exists():
+            self.skipTest("Sample PDF not available")
+        self.cfg = PyPdfToTextConfig(overrides={
+            "DISABLE_OCR": False,
+            "MIN_LINES_OCR_TRIGGER": 1,
+            "TRIGGER_OCR_PAGE_RATIO": 0.5,
+            "DISABLE_PROGRESS_BAR": True,
+            "MAX_CHARS_PER_PDF_PAGE": 25000,
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+
+    def _build_success_ocr_result(self, extract):
+        """Build a synthetic successful OCRResult for the pages extract needs."""
+        from pypdftotext.ocr_result import OCRResult
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        ocr_idxs = extract.ocr_page_idxs
+        raw = AnalyzeResult({
+            "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+            "stringIndexType": "textElements",
+            "content": " ".join(f"page{i}" for i in ocr_idxs),
+            "pages": [
+                {"pageNumber": i + 1, "angle": 0.0, "width": 8.5,
+                 "height": 11.0, "unit": "inch",
+                 "spans": [{"offset": idx_pos * 6, "length": 5}],
+                 "words": [], "lines": [], "selectionMarks": []}
+                for idx_pos, i in enumerate(ocr_idxs)
+            ],
+            "styles": [],
+        })
+        pages = [f"OCR_PAGE_{i}" for i in ocr_idxs]
+        return OCRResult(
+            pdf_name=extract.pdf_name, config=extract.config,
+            raw=raw, pages=pages,
+        )
+
+    def test_ocr_end_to_end_success(self):
+        """Mocked azure produces a successful OCRResult; ExtractedPages reflect it."""
+        from pypdftotext.pdf_extract import PdfExtract
+        from unittest.mock import patch
+        # Force OCR by suppressing embedded text on every page.
+        cfg = PyPdfToTextConfig(base=self.cfg, overrides={"SUPPRESS_EMBEDDED_TEXT": True})
+        extract = PdfExtract(self.pdf_path.read_bytes(), config=cfg, pdf_name="t.pdf")
+        # Trigger _extract_pages so ocr_page_idxs is populated, but don't run ocr() yet.
+        extract._extracted_pages = None
+        with patch(
+            "pypdftotext.pdf_extract.AzureDocIntelIntegrator"
+        ) as mock_cls:
+            mock_azure = mock_cls.return_value
+            # When ocr() is invoked, return a fake OCRResult via await_one.
+            mock_azure.submit.return_value = MagicMock(name="poller")
+            mock_azure.await_one.side_effect = lambda p, **kw: self._build_success_ocr_result(extract)
+            _ = extract.extracted_pages
+        self.assertIsNotNone(extract.ocr_result)
+        self.assertTrue(extract.ocr_result.succeeded)
+        # Every page that was OCR'd has source="OCR" and non-empty text.
+        for idx in extract.ocr_page_idxs:
+            self.assertEqual(extract.extracted_pages[idx].source, "OCR")
+            self.assertTrue(extract.extracted_pages[idx].text.startswith("OCR_PAGE_"))
+            self.assertIsNone(extract.extracted_pages[idx].ocr_error)
+
+    def test_ocr_end_to_end_failure_sets_ocr_error(self):
+        """Mocked azure returns OCRResult with error; ExtractedPages get ocr_error."""
+        from pypdftotext.pdf_extract import PdfExtract
+        from pypdftotext.ocr_result import OCRResult
+        from unittest.mock import patch
+        cfg = PyPdfToTextConfig(base=self.cfg, overrides={"SUPPRESS_EMBEDDED_TEXT": True})
+        extract = PdfExtract(self.pdf_path.read_bytes(), config=cfg, pdf_name="t.pdf")
+        extract._extracted_pages = None
+        failure = OCRResult(
+            pdf_name="t.pdf", config=cfg, raw=None, pages=[],
+            error="OCR timeout: simulated for test",
+        )
+        with patch(
+            "pypdftotext.pdf_extract.AzureDocIntelIntegrator"
+        ) as mock_cls:
+            mock_azure = mock_cls.return_value
+            mock_azure.submit.return_value = MagicMock(name="poller")
+            mock_azure.await_one.return_value = failure
+            _ = extract.extracted_pages
+        self.assertIsNotNone(extract.ocr_result)
+        self.assertFalse(extract.ocr_result.succeeded)
+        for idx in extract.ocr_page_idxs:
+            self.assertEqual(
+                extract.extracted_pages[idx].ocr_error, "OCR timeout: simulated for test",
+            )
+            self.assertEqual(extract.extracted_pages[idx].text, "")
+            self.assertEqual(extract.extracted_pages[idx].source, "embedded")
+
+    def test_ocr_logs_no_false_success_on_failure(self):
+        """The misleading 'OCR'd successfully' log must not fire on failure."""
+        from pypdftotext.pdf_extract import PdfExtract
+        from pypdftotext.ocr_result import OCRResult
+        from unittest.mock import patch
+        cfg = PyPdfToTextConfig(base=self.cfg, overrides={"SUPPRESS_EMBEDDED_TEXT": True})
+        extract = PdfExtract(self.pdf_path.read_bytes(), config=cfg, pdf_name="t.pdf")
+        extract._extracted_pages = None
+        failure = OCRResult(
+            pdf_name="t.pdf", config=cfg, raw=None, pages=[],
+            error="OCR failed: HttpResponseError: simulated",
+        )
+        with patch("pypdftotext.pdf_extract.AzureDocIntelIntegrator") as mock_cls:
+            mock_azure = mock_cls.return_value
+            mock_azure.submit.return_value = MagicMock(name="poller")
+            mock_azure.await_one.return_value = failure
+            with self.assertLogs("pypdftotext", level="INFO") as captured:
+                # Trigger the OCR path.
+                _ = extract.extracted_pages
+        # Assert no "successfully" log emitted at INFO.
+        success_lines = [line for line in captured.output if "successfully" in line.lower()]
+        self.assertEqual(success_lines, [])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+<PREFIX> pytest tests/test_pdf_extract.py::TestOcrEndToEnd -v
+```
+
+Expected: FAIL — `AttributeError: 'PdfExtract' object has no attribute 'ocr_result'` (or similar).
+
+- [ ] **Step 3: Add `ocr_result` attribute and `_apply_ocr_result` to `PdfExtract`**
+
+In `pypdftotext/pdf_extract.py`:
+
+1. Add import near the top (with other internal imports):
+
+```python
+from .azure_docintel_integrator import AZURE_READ
+from .ocr_result import OCRResult
+```
+
+2. Initialize `self.ocr_result` in `PdfExtract.__init__` (around line 107, near where `self.ocr_page_idxs` is initialized):
+
+```python
+        self.ocr_page_idxs: list[int] = []
+        self.ocr_result: OCRResult | None = None  # set by ocr() if OCR runs
+```
+
+3. Update the docstring `Args/KwArgs` section of `__init__` to mention `self.ocr_result` under a new heading after `KwArgs`:
+
+```
+    Attributes (set after extraction):
+        ocr_result: Result of the OCR call if OCR ran; None if OCR was
+            never attempted (e.g. all pages had sufficient embedded text).
+            On failure, ocr_result.succeeded is False and ocr_result.error
+            describes the failure.
+```
+
+4. Rewrite `PdfExtract.ocr` (currently lines 326-392). Replace the entire method with:
+
+```python
+    def ocr(self, azure: AzureDocIntelIntegrator | None = None):
+        """Run OCR on the pages identified during _extract_pages, applying
+        results to self.extracted_pages.
+
+        Args:
+            azure: integrator to use. Defaults to the canonical AZURE_READ
+                singleton; pass an explicit instance if you need credential
+                isolation across PdfExtract instances.
+        """
+        if azure is None:
+            azure = AZURE_READ
+        if (
+            len(self.ocr_page_idxs) / len(self.extracted_pages)
+            < self.config.TRIGGER_OCR_PAGE_RATIO
+        ):
+            return
+        poller = azure.submit(
+            self.body, self.ocr_page_idxs, pdf_name=self.pdf_name, config=self.config,
+        )
+        if poller is None:
+            # No client available; await_one wasn't called so log here.
+            logger.error(
+                "[%s] OCR submit failed: no client available", self.pdf_name,
+            )
+            return
+        result = azure.await_one(poller, pdf_name=self.pdf_name, config=self.config)
+        self._apply_ocr_result(result)
+
+    def _apply_ocr_result(self, result: OCRResult) -> None:
+        """Apply an OCRResult to self.extracted_pages.
+
+        On success: each ocr_page_idx page gets its rendered text,
+        source="OCR", handwritten_ratio, and azure_page populated; rotations
+        are applied where Azure reports non-zero angles.
+
+        On failure: every ocr_page_idx page gets ocr_error set; text stays
+        empty, source stays "embedded", azure_page stays None.
+
+        In both cases self.ocr_result is stashed for downstream introspection.
+        """
+        self.ocr_result = result
+        rotated_pages = False
+        if not result.succeeded:
+            for og_pg_idx in self.ocr_page_idxs:
+                self.extracted_pages[og_pg_idx].ocr_error = result.error
+            return
+        # Replacement substitutions only run in batch mode (single-mode
+        # replacements happen globally in _extract_pages).
+        replacements = (
+            [
+                (old_bytes.decode(), new_bytes.decode())
+                for old_bytes, new_bytes in (self.config.REPLACE_BYTE_CODES or {}).items()
+            ]
+            if self._batch_mode
+            else []
+        )
+        for ocr_idx, og_pg_idx in enumerate(self.ocr_page_idxs):
+            ext_pg = self.extracted_pages[og_pg_idx]
+            txt = result.pages[ocr_idx]
+            if len(txt) > self.config.MAX_CHARS_PER_PDF_PAGE:
+                logger.warning(
+                    "[%s] Clearing corrupt OCR text pg_idx=%s; len(txt)=%s > %s char limit."
+                    " Does page contain multiple text orientations?",
+                    self.pdf_name, og_pg_idx, len(txt),
+                    self.config.MAX_CHARS_PER_PDF_PAGE,
+                )
+                txt = ""
+            elif rotation := result.rotation_degrees(og_pg_idx):
+                if applied_rotation := -90 * int(round(rotation / 90.0)):
+                    rotated_pages = True
+                    ext_pg.page_obj.rotation += applied_rotation
+            if replacements and txt:
+                for old_, new_ in replacements:
+                    txt = txt.replace(old_, new_)
+            ext_pg.text = txt
+            ext_pg.source = "OCR"
+            ext_pg.handwritten_ratio = result.handwritten_ratio(og_pg_idx)
+            ext_pg.azure_page = result.page_at_index(og_pg_idx)
+            ext_pg.ocr_error = None
+        if rotated_pages:
+            logger.debug("[%s] Regenerating body with corrected page orientations.", self.pdf_name)
+            self._regenerate_body()
+```
+
+5. Update `_extract_pages` (around lines 302-308) to drop the `self._azure.config = self.config` mutation and pass the integrator directly:
+
+```python
+        if self._azure is not None:
+            azure = self._azure
+        else:
+            azure = AZURE_READ
+
+        # Parallel Azure OCR API calls will be made later if in batch mode.
+        if not self._batch_mode:
+            self.ocr(azure)
+```
+
+(The previous code created a fresh `AzureDocIntelIntegrator(self.config)` per call; the new code uses `AZURE_READ` by default and respects an explicit `self._azure` injection.)
+
+6. Update the debug-write code (formerly lines 350-359 in the original; line numbers will have shifted). The references to `azure.last_result.as_dict()` / `azure.last_result.content` introduced as temporary in Task 8 (`azure._thread_local.last_result...`) should now read from `self.ocr_result.raw`:
+
+```python
+            if self.debug_path and self.ocr_result is not None:
+                (self.debug_path / "ocr_pages.json").write_text(
+                    json.dumps(self.ocr_result.pages, indent=2, default=str),
+                    "utf-8",
+                )
+                if self.ocr_result.raw is not None:
+                    (self.debug_path / "azure.json").write_text(
+                        json.dumps(self.ocr_result.raw.as_dict(), indent=2),
+                        "utf-8",
+                    )
+                    (self.debug_path / "azure_content.txt").write_text(
+                        self.ocr_result.raw.content or "",
+                        "utf-8",
+                    )
+```
+
+Place this block at the end of `_apply_ocr_result` (after `if rotated_pages:`).
+
+Wait — `self.debug_path` is a `PdfExtract` instance attribute. `_apply_ocr_result` is a method on `PdfExtract`, so `self.debug_path` is in scope. Good.
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_pdf_extract.py -v
+```
+
+Expected: new `TestOcrEndToEnd` tests PASS; existing tests in `test_pdf_extract.py` continue to PASS.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+<PREFIX> pytest tests/ -v
+```
+
+Expected: all PASS. `test_batch.py` will continue to pass because `_perform_batch_ocr` still uses the legacy path (Task 14 changes it).
+
+- [ ] **Step 6: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/pdf_extract.py
+<PREFIX> pyright pypdftotext/pdf_extract.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pypdftotext/pdf_extract.py tests/test_pdf_extract.py
+git commit -m "Rewrite PdfExtract.ocr to use submit + await_one + OCRResult
+
+Adds PdfExtract.ocr_result (None until OCR runs), _apply_ocr_result handles
+success and failure uniformly: success paths populate text/source/handwritten/
+azure_page; failure paths set ExtractedPage.ocr_error. Default integrator
+is now the AZURE_READ singleton. Removes the self._azure.config = self.config
+mutation in favor of per-call config kwargs."
+```
+
+---
+
+### Task 14: Rewrite `PdfExtractBatch._perform_batch_ocr` for submit-and-await
+
+**Files:**
+
+- Modify: `pypdftotext/batch.py`
+- Test: `tests/test_batch.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_batch.py`:
+
+```python
+class TestPerformBatchOcrSubmitAndAwait(unittest.TestCase):
+    """Coverage tests for the rewritten _perform_batch_ocr."""
+
+    def setUp(self):
+        from pathlib import Path
+        self.samples_dir = Path("samples")
+        if not (self.samples_dir / "all70th.pdf").exists():
+            self.skipTest("Sample PDF not available")
+        self.pdf_bytes = (self.samples_dir / "all70th.pdf").read_bytes()
+        self.cfg = PyPdfToTextConfig(overrides={
+            "DISABLE_OCR": False,
+            "MIN_LINES_OCR_TRIGGER": 1,
+            "TRIGGER_OCR_PAGE_RATIO": 0.5,
+            "DISABLE_PROGRESS_BAR": True,
+            "MAX_CHARS_PER_PDF_PAGE": 25000,
+            "SUPPRESS_EMBEDDED_TEXT": True,
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+
+    def test_perform_batch_ocr_uses_azure_read_no_threadpool(self):
+        """Batch dispatches via AZURE_READ.submit + module-level await_all;
+        does NOT instantiate a ThreadPoolExecutor for OCR."""
+        from pypdftotext import AZURE_READ
+        from pypdftotext.batch import PdfExtractBatch
+        from pypdftotext.ocr_result import OCRResult
+        from unittest.mock import patch
+
+        batch = PdfExtractBatch({"a": self.pdf_bytes, "b": self.pdf_bytes}, config=self.cfg)
+        fake_poller = MagicMock(name="poller")
+
+        def fake_await_all(pollers, integrator, timeout, *, config=None):
+            return {
+                name: OCRResult(
+                    pdf_name=name, config=config or self.cfg, raw=None,
+                    pages=["OCR_TEXT"] * len(batch.pdf_extracts[name].ocr_page_idxs),
+                    error=None,
+                )
+                for name in pollers
+            }
+
+        with patch.object(AZURE_READ, "submit", return_value=fake_poller) as mock_submit, \
+             patch("pypdftotext.batch.await_all", side_effect=fake_await_all) as mock_await_all, \
+             patch("pypdftotext.batch.ThreadPoolExecutor") as mock_pool:
+            batch.extract_all()
+        # Submit was called once per PDF.
+        self.assertEqual(mock_submit.call_count, 2)
+        # await_all was called once with both pollers.
+        self.assertEqual(mock_await_all.call_count, 1)
+        args, kwargs = mock_await_all.call_args
+        pollers_arg = args[0] if args else kwargs["pollers"]
+        self.assertEqual(set(pollers_arg.keys()), {"a", "b"})
+        # ThreadPoolExecutor must NOT be constructed inside _perform_batch_ocr.
+        # (It is still used in _pull_s3_parallel for S3 fetches, but our inputs
+        # are bytes — _pull_s3_parallel short-circuits.)
+        self.assertEqual(mock_pool.call_count, 0)
+
+    def test_partial_failure_does_not_crash_batch(self):
+        """One PDF fails OCR (error result); the other succeeds; batch returns both."""
+        from pypdftotext import AZURE_READ
+        from pypdftotext.batch import PdfExtractBatch
+        from pypdftotext.ocr_result import OCRResult
+        from unittest.mock import patch
+
+        batch = PdfExtractBatch({"good": self.pdf_bytes, "bad": self.pdf_bytes}, config=self.cfg)
+        fake_poller = MagicMock(name="poller")
+
+        def fake_await_all(pollers, integrator, timeout, *, config=None):
+            good_pages = ["OCR_GOOD"] * len(batch.pdf_extracts["good"].ocr_page_idxs)
+            return {
+                "good": OCRResult(
+                    pdf_name="good", config=config or self.cfg, raw=None,
+                    pages=good_pages, error=None,
+                ),
+                "bad": OCRResult(
+                    pdf_name="bad", config=config or self.cfg, raw=None,
+                    pages=[], error="OCR timeout: simulated",
+                ),
+            }
+
+        with patch.object(AZURE_READ, "submit", return_value=fake_poller), \
+             patch("pypdftotext.batch.await_all", side_effect=fake_await_all):
+            results = batch.extract_all()
+        # Both PDFs are in the results dict.
+        self.assertIn("good", results)
+        self.assertIn("bad", results)
+        # Good has OCR text populated.
+        good_extract = results["good"]
+        for idx in good_extract.ocr_page_idxs:
+            self.assertEqual(good_extract.extracted_pages[idx].text, "OCR_GOOD")
+            self.assertIsNone(good_extract.extracted_pages[idx].ocr_error)
+        # Bad has ocr_error set on all OCR pages.
+        bad_extract = results["bad"]
+        for idx in bad_extract.ocr_page_idxs:
+            self.assertEqual(
+                bad_extract.extracted_pages[idx].ocr_error, "OCR timeout: simulated",
+            )
+            self.assertEqual(bad_extract.extracted_pages[idx].text, "")
+```
+
+Note: The lambda inside the OCRResult succeeded check is intentionally `raw=None` even though `succeeded` would normally need a real `AnalyzeResult`. The `_apply_ocr_result` method only checks `result.succeeded` for the success branch; with `raw=None`, `succeeded` is False. **Adjust the success test mock to use a populated AnalyzeResult so success path is exercised.** Replace the `good` OCRResult with one carrying a real raw object built like in `TestAwaitOne._populated_analyze_result`. Use the same builder pattern.
+
+For simplicity in the test, override `_apply_ocr_result` directly per case OR construct a real `AnalyzeResult`. Here's the corrected `fake_await_all` for `test_perform_batch_ocr_uses_azure_read_no_threadpool` and the good case in `test_partial_failure_does_not_crash_batch`:
+
+```python
+        def _make_raw(extract):
+            from azure.ai.documentintelligence.models import AnalyzeResult
+            ocr_idxs = extract.ocr_page_idxs
+            return AnalyzeResult({
+                "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+                "stringIndexType": "textElements",
+                "content": " ".join(f"p{i}" for i in ocr_idxs),
+                "pages": [
+                    {"pageNumber": i + 1, "angle": 0.0, "width": 8.5,
+                     "height": 11.0, "unit": "inch",
+                     "spans": [{"offset": pos * 3, "length": 2}],
+                     "words": [], "lines": [], "selectionMarks": []}
+                    for pos, i in enumerate(ocr_idxs)
+                ],
+                "styles": [],
+            })
+```
+
+Adjust the OCRResult construction in both tests to use `raw=_make_raw(extract)` for successful entries.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+<PREFIX> pytest tests/test_batch.py::TestPerformBatchOcrSubmitAndAwait -v
+```
+
+Expected: FAIL — `_perform_batch_ocr` currently uses `ThreadPoolExecutor`, so `mock_pool.call_count` will be ≥ 1. Also `await_all` is not yet imported in `batch.py`.
+
+- [ ] **Step 3: Rewrite `_perform_batch_ocr`**
+
+In `pypdftotext/batch.py`:
+
+1. Update the imports near the top:
+
+```python
+from .azure_docintel_integrator import AzureDocIntelIntegrator, await_all
+from .. import AZURE_READ  # (or `from pypdftotext import AZURE_READ`; pick whichever resolves)
+```
+
+The cleanest is to import from the integrator module directly:
+
+```python
+from .azure_docintel_integrator import (
+    AzureDocIntelIntegrator,
+    AZURE_READ,
+    await_all,
+)
+```
+
+2. Replace the body of `_perform_batch_ocr` (lines 180-222 in the current file) with:
+
+```python
+    def _perform_batch_ocr(self) -> dict[str, PdfExtract]:
+        """Submit all OCR-eligible PDFs, await collectively, apply results."""
+        ocr_pdfs = {
+            pdf_name: extract
+            for pdf_name, extract in self.pdf_extracts.items()
+            if (
+                len(extract.ocr_page_idxs) / len(extract.extracted_pages)
+                >= self.config.TRIGGER_OCR_PAGE_RATIO
+            )
+        }
+        if not ocr_pdfs:
+            logger.debug(
+                "No PDFs met OCR criteria (MIN_LINES_OCR_TRIGGER=%s, TRIGGER_OCR_PAGE_RATIO=%s)",
+                self.config.MIN_LINES_OCR_TRIGGER,
+                self.config.TRIGGER_OCR_PAGE_RATIO,
+            )
+            return self.pdf_extracts
+        total_pages = sum(len(ext.ocr_page_idxs) for ext in ocr_pdfs.values())
+        logger.info(
+            "Submitting %s pages across %s PDFs for batch OCR", total_pages, len(ocr_pdfs),
+        )
+        # Phase 1: submit all
+        pollers = {}
+        for pdf_name, extract in ocr_pdfs.items():
+            poller = AZURE_READ.submit(
+                extract.body, extract.ocr_page_idxs,
+                pdf_name=pdf_name, config=self.config,
+            )
+            if poller is not None:
+                pollers[pdf_name] = poller
+            else:
+                # No client available; record failure inline.
+                from .ocr_result import OCRResult
+                extract._apply_ocr_result(OCRResult(
+                    pdf_name=pdf_name, config=self.config, raw=None, pages=[],
+                    error="OCR failed: no client available "
+                          "(check AZURE_DOCINTEL_ENDPOINT and AZURE_DOCINTEL_SUBSCRIPTION_KEY)",
+                ))
+        # Phase 2: collective wait
+        results = await_all(
+            pollers, AZURE_READ,
+            timeout=self.config.AZURE_DOCINTEL_TIMEOUT,
+            config=self.config,
+        )
+        # Phase 3: apply
+        for pdf_name, extract in ocr_pdfs.items():
+            if pdf_name in results:
+                try:
+                    extract._apply_ocr_result(results[pdf_name])
+                except Exception as e:  # noqa: BLE001  # batch survives per-PDF apply failures
+                    logger.error(
+                        "PdfExtractBatch apply error for %s: %s", pdf_name, e,
+                        exc_info=logger.getEffectiveLevel() == logging.DEBUG,
+                    )
+        return self.pdf_extracts
+```
+
+3. Remove the now-unused `_ocr_single_pdf` method (lines 224-250 in the current file).
+
+4. Remove the now-unused imports from the top of `batch.py`:
+
+```python
+# Remove:
+from concurrent.futures import Future, as_completed
+from azure.core.exceptions import AzureError
+```
+
+Keep `ThreadPoolExecutor` import — it's still used by `_pull_s3_parallel`.
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+<PREFIX> pytest tests/test_batch.py -v
+```
+
+Expected: new `TestPerformBatchOcrSubmitAndAwait` tests PASS; existing `TestPdfExtractBatch` tests PASS.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+<PREFIX> pytest tests/ -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Lint and type check**
+
+```bash
+<PREFIX> ruff check pypdftotext/batch.py
+<PREFIX> ruff format --check pypdftotext/
+<PREFIX> pyright pypdftotext/
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Final doctest sweep**
+
+```bash
+<PREFIX> pytest --doctest-modules pypdftotext/
+```
+
+Expected: all PASS, including the new OCRResult doctests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pypdftotext/batch.py tests/test_batch.py
+git commit -m "Rewrite PdfExtractBatch._perform_batch_ocr for submit-and-await
+
+Replaces the per-PDF ThreadPoolExecutor with: submit all → await_all collective
+wait → apply results serially. Drops _ocr_single_pdf and its imports. The S3
+fetch ThreadPoolExecutor in _pull_s3_parallel is unaffected. PDFs without an
+available client get an inline failure OCRResult applied; partial failures
+don't crash the batch."
+```
+
+---
+
+## Self-Review
+
+After all 14 tasks are complete:
+
+- [ ] **Run the full pre-merge check sequence:**
+
+```bash
+<PREFIX> pytest tests/ -v
+<PREFIX> pytest --doctest-modules pypdftotext/
+<PREFIX> ruff check pypdftotext/
+<PREFIX> ruff format --check pypdftotext/
+<PREFIX> pyright pypdftotext/
+```
+
+All expected: PASS / no errors.
+
+- [ ] **Diff inspection:**
+
+```bash
+git log --oneline main..HEAD     # or the appropriate base branch
+git diff main..HEAD --stat       # see file-level summary
+```
+
+Confirm:
+- New files: `pypdftotext/ocr_result.py`, `pypdftotext/_cancellable_polling.py`, `tests/test_azure_docintel_integrator.py`, `tests/test_cancellable_polling.py`, `tests/test_await_all.py`.
+- Modified files match the File Structure section above.
+- No unintended drift in unrelated modules.
+
+- [ ] **Verify the original bug is fixed:**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py::TestAwaitOne::test_await_one_timeout_yields_error_result -v
+```
+
+This is the regression test. PASS confirms the silent-`None` timeout no longer crashes downstream.
+
+- [ ] **Verify P4 contamination is fixed:**
+
+```bash
+<PREFIX> pytest tests/test_azure_docintel_integrator.py::TestThreadLocalIsolation::test_thread_local_isolation_across_threads -v
+```
+
+PASS confirms two threads sharing one integrator each see their own result.
+
+- [ ] **Verify the batch path no longer uses ThreadPoolExecutor for OCR:**
+
+```bash
+<PREFIX> pytest tests/test_batch.py::TestPerformBatchOcrSubmitAndAwait::test_perform_batch_ocr_uses_azure_read_no_threadpool -v
+```
+
+PASS confirms the architecture change.
+
+If any check fails, fix the underlying issue and re-run. Do not skip checks to make the suite pass.
+
+---
+
+## Notes for the implementer
+
+- **Order matters.** Tasks 8 → 9 → 10 deal with the `last_result` migration. Task 8 removes the dataclass field, Task 9 reintroduces it as a deprecated property, Task 10 deprecates the methods that read it. Don't reorder.
+- **`samples/` fixtures.** Tests reference `samples/all70th.pdf` and `samples/all70th.bin` (a pickled `AnalyzeResult`). If those don't exist locally, the relevant tests will `skipTest()`. That's expected for environments without the fixtures; CI should have them.
+- **DeprecationWarning noise during tests.** Existing tests that call deprecated methods will emit warnings to stderr but won't fail. If you want to suppress them globally for clean CI output, add to `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::DeprecationWarning:pypdftotext.azure_docintel_integrator",
+]
+```
+
+This is optional and out of scope for the spec — only add if the test output is noisy enough to bother you.
+
+- **Commit hygiene.** Each task should produce exactly one commit. The commit messages in this plan are starting points — feel free to refine them, but keep each commit focused on its single task.
+
+- **If a step's expected output doesn't match reality:** stop and investigate. Don't paper over a failing test with a `skip` decorator or change the assertion to match buggy behavior. The plan's expected outputs are the contract; deviation means either the plan is wrong (file an issue / amend the plan) or your implementation has a bug.

--- a/docs/superpowers/specs/2026-05-13-ocr-submit-and-await-design.md
+++ b/docs/superpowers/specs/2026-05-13-ocr-submit-and-await-design.md
@@ -1,0 +1,507 @@
+# OCR Submit-and-Await: Design Spec
+
+**Date:** 2026-05-13
+**Status:** Draft (pre-implementation)
+**Scope:** Internal restructure of OCR plumbing in `pypdftotext`. Public API surface (`PdfExtract`, `PdfExtractBatch`, `ExtractedPage`, `pdf_text_pages`, `pdf_text_page_lines`, `AZURE_READ`) remains backward-compatible. Adds `OCRResult` to the public API and one new field each to `ExtractedPage` and `PyPdfToTextConfig`.
+
+---
+
+## TL;DR
+
+- Fix the original bug: `poller.result(timeout)` returns `None` on timeout, downstream code accesses `None.pages` and raises `AttributeError`. The misleading `INFO "OCR'd successfully"` log fires regardless of result validity.
+- Replace `AzureDocIntelIntegrator.last_result` (session-scoped mutable state) with an immutable per-call `OCRResult` value type. Eliminates a class of cross-thread contamination (pattern P4 below).
+- Restructure the batch path from "thread-pool-per-PDF + blocking poller" to "submit all → collective await". Removes one layer of threading and consolidates connection pooling behind a single shared `DocumentIntelligenceClient`.
+- Cancel pending pollers cleanly on timeout via a `CancellablePolling` subclass — no stranded daemon threads.
+- Soft-fail on OCR errors: log, set `ExtractedPage.ocr_error`, never raise. Public API gains no new exception types.
+- Back-compat preserved: deprecated `AZURE_READ.last_result` and the integrator's `handwritten_ratio` / `rotation_degrees` / `page_at_index` continue to work via `threading.local()`, with `DeprecationWarning`.
+
+---
+
+## Background
+
+### Original bug
+
+[`AzureDocIntelIntegrator.ocr_pages`](../../../pypdftotext/azure_docintel_integrator.py) at line 89:
+
+```python
+self.last_result = poller.result(self.config.AZURE_DOCINTEL_TIMEOUT)
+logger.info("%s%s pages OCR'd successfully. Creating fixed width pages.", prefix, len(pages))
+ocr_pbar = tqdm(self.last_result.pages, ...)
+```
+
+The Azure SDK's `LROPoller.result(timeout)` does **not** raise on timeout. From `azure.core.polling._poller.LROPoller`:
+
+```python
+def result(self, timeout=None):
+    self.wait(timeout)
+    return self._polling_method.resource()
+
+def wait(self, timeout=None):
+    self._thread.join(timeout=timeout)
+    try:
+        raise self._exception
+    except TypeError:   # _exception is None when the thread is still running
+        pass
+```
+
+`Thread.join(timeout)` returns silently when the timeout elapses. The polling daemon thread continues running. `self._exception` is `None` so the `raise None` raises `TypeError`, which is swallowed. Control proceeds to `_polling_method.resource()`, which calls the deserialization callback on the most recent polled response (typically `{"status": "running", ...}` with no `analyzeResult` key). `_deserialize(AnalyzeResult, None)` returns `None`.
+
+Result: `self.last_result = None`, success log fires, then `self.last_result.pages` raises `AttributeError: 'NoneType' object has no attribute 'pages'`.
+
+### Cross-thread contamination patterns
+
+| Pattern | Description | Currently safe? |
+| --- | --- | --- |
+| **P1** | Multi-process (Celery, multiprocessing). One `PdfExtract` per process. | ✅ |
+| **P2** | Multi-thread. One `PdfExtract` per thread (each thread builds its own integrator via `_extract_pages` line 304). | ✅ |
+| **P3** | Multi-thread sharing one `PdfExtract`. | ❌ — `PdfReader`/`PdfWriter` not thread-safe. Documented. **Out of scope for this rewrite; deferred to a follow-up spec.** |
+| **P4** | Multi-thread sharing one `AzureDocIntelIntegrator` (e.g. passing `AZURE_READ` to many `PdfExtract` instances across threads). | ❌ — `last_result` is overwritten; `handwritten_ratio(idx)` returns data from the most recently completed OCR, for the wrong PDF. **Silent corruption.** This rewrite fixes P4 by construction. |
+
+### Threading inefficiency
+
+`PdfExtractBatch._perform_batch_ocr` spawns `MAX_WORKERS=10` worker threads. Each worker calls `poller.result(timeout)`, which itself spawns a daemon polling thread inside the SDK. So `~20` threads per batch where `~10` are doing nothing but `Thread.join()`.
+
+The poller already encapsulates the asynchronous wait. The user-level worker thread adds no value — it exists solely because `poller.result()` is a blocking interface.
+
+---
+
+## Goals
+
+1. Fix the original bug: no silent `None` results, no misleading success log, no `AttributeError` downstream.
+2. Eliminate P4 contamination structurally — no session-scoped mutable result state on the integrator.
+3. Reduce the batch path's thread count by ~50% by replacing worker-thread-per-PDF with collective wait.
+4. Consolidate `DocumentIntelligenceClient` instances behind credential-keyed caching, sized via config.
+5. Clean up pending pollers on timeout — no stranded daemon threads.
+6. Preserve full backward compatibility for currently-public API surfaces, with deprecation warnings on retired surfaces.
+
+## Non-goals
+
+- Switching to `asyncio` / `AsyncDocumentIntelligenceClient`. Conflict with caller event loops makes this riskier than the value it adds; sync SDK throughout.
+- Continuation-token-based crash recovery. Feasible (`poller.continuation_token()` exposed by SDK) but out of scope for this effort.
+- Cancelling Azure-side processing. The Document Intelligence API has no cancel endpoint; we can only stop *waiting* locally.
+- P3 thread-safety. Tracked separately; revisit after this rewrite lands.
+- New exception types in the public API. Soft-fail with `ocr_error` attribute is the chosen failure model.
+
+---
+
+## Design
+
+### Architecture
+
+**Before:**
+
+```text
+PdfExtract.ocr()
+  └─> azure.ocr_pages(pdf, pages)
+        └─> blocks on poller.result(timeout)
+              └─> writes azure.last_result  ← mutable session state, P4 footgun
+
+PdfExtractBatch._perform_batch_ocr()
+  └─> ThreadPoolExecutor(MAX_WORKERS)
+        └─> for each PDF: new AzureDocIntelIntegrator(), new client, .ocr_pages(...)
+              └─> N×2 threads (worker + SDK poller daemon)
+```
+
+**After:**
+
+```text
+azure_docintel_integrator.py
+  ├── AzureDocIntelIntegrator       (stateless re: results; holds default config + thread-local back-compat)
+  │     ├── submit(pdf, pages, *, config=None) -> AnalyzeDocumentLROPoller | None    [non-blocking]
+  │     └── await_one(poller, *, config=None) -> OCRResult                           [blocking, per-PDF]
+  ├── OCRResult                     (new public dataclass — pages, raw AnalyzeResult, error)
+  ├── CancellablePolling            (LROBasePolling subclass with a cancel Event)
+  ├── AZURE_READ                    (canonical shared instance; existing public export)
+  └── module-level helpers
+        ├── client_for(config) -> DocumentIntelligenceClient | None    [cached by (endpoint, key)]
+        └── await_all(pollers, integrator, timeout, *, config=None) -> dict[str, OCRResult]
+
+pdf_extract.py
+  └── PdfExtract.ocr(azure=AZURE_READ)
+        ├── poller = azure.submit(self.body, self.ocr_page_idxs, pdf_name=…, config=self.config)
+        ├── result = azure.await_one(poller, pdf_name=…, config=self.config)
+        └── self._apply_ocr_result(result)
+
+batch.py
+  └── PdfExtractBatch._perform_batch_ocr()
+        ├── pollers = {name: AZURE_READ.submit(ext.body, ext.ocr_page_idxs, pdf_name=name, config=self.config)
+        │              for name, ext in ocr_pdfs.items()}
+        ├── results = await_all(pollers, AZURE_READ, timeout=self.config.AZURE_DOCINTEL_TIMEOUT,
+        │                       config=self.config)
+        └── for name, ext in ocr_pdfs.items(): ext._apply_ocr_result(results[name])
+                                ↑ no worker thread pool; one SDK daemon poll thread per poller
+```
+
+### Components
+
+#### `OCRResult` — new public dataclass
+
+```python
+@dataclass(frozen=True)
+class OCRResult:
+    """Value type returned by a single OCR call. Replaces session-scoped last_result."""
+    pdf_name: str
+    config: PyPdfToTextConfig             # config snapshot used at OCR time
+    raw: AnalyzeResult | None             # underlying SDK result; None on hard failure
+    pages: list[str]                      # rendered fixed-width text, one per submitted page index
+    error: str | None = None              # human-readable failure reason; None on success
+
+    @property
+    def succeeded(self) -> bool:
+        return self.error is None and self.raw is not None and bool(self.raw.pages)
+
+    def handwritten_ratio(self, page_index: int) -> float: ...
+    def rotation_degrees(self, page_index: int) -> float: ...
+    def page_at_index(self, page_index: int) -> DocumentPage | None: ...
+```
+
+The three methods are relocated from `AzureDocIntelIntegrator` with identical semantics. They read `self.config` for thresholds (`OCR_HANDWRITTEN_CONFIDENCE_LIMIT`, `MIN_OCR_ROTATION_DEGREES`).
+
+`OCRResult` is added to `pypdftotext/__init__.py`'s `__all__`.
+
+#### `AzureDocIntelIntegrator` — new methods, deprecated old surface
+
+```python
+class AzureDocIntelIntegrator:
+    config: PyPdfToTextConfig
+    client: DocumentIntelligenceClient | None   # legacy: prefer client_for(config)
+    _thread_local: threading.local              # NEW: per-thread last_result/ocr_result for back-compat
+
+    # === New API ===
+    def submit(self, pdf, pages, pdf_name="", *, config=None) -> AnalyzeDocumentLROPoller | None:
+        """Submit pages for OCR. Returns a poller, or None if no client is configured.
+        Passes a CancellablePolling instance so await_one can cancel cleanly."""
+
+    def await_one(self, poller, pdf_name="", *, config=None) -> OCRResult:
+        """Wait for one poller to complete (cfg.AZURE_DOCINTEL_TIMEOUT). On timeout:
+        sets the poller's cancel event, builds OCRResult with error set, updates
+        self._thread_local for back-compat."""
+
+    def ocr_pages(self, pdf, pages, pdf_name="") -> list[str]:
+        """Thin wrapper: submit + await_one. Signature unchanged from current."""
+
+    # === Deprecated (emit DeprecationWarning; back-compat via _thread_local) ===
+    @property
+    def last_result(self) -> AnalyzeResult: ...
+    def handwritten_ratio(self, page_index, handwritten_confidence_limit=None) -> float: ...
+    def rotation_degrees(self, page_index) -> float: ...
+    def page_at_index(self, page_index) -> DocumentPage | None: ...
+    def reset(self) -> None: ...   # clears thread-local
+```
+
+#### Module-level helpers
+
+```python
+_client_cache: dict[tuple[str, str], DocumentIntelligenceClient] = {}
+_client_cache_lock: threading.Lock = threading.Lock()
+
+def client_for(config: PyPdfToTextConfig) -> DocumentIntelligenceClient | None:
+    """Return a cached client for (endpoint, key). Builds a new one with a sized
+    urllib3 pool (config.AZURE_CLIENT_POOL_MAXSIZE) if not cached. Returns None
+    if endpoint or key is missing."""
+
+_BUDGET_GRACE_SECONDS: float = 5.0
+"""How long await_all waits after signalling cancellation for late callbacks to fire
+before synthesizing 'budget exceeded' results. Internal tuning constant; not configurable."""
+
+def await_all(
+    pollers: Mapping[str, AnalyzeDocumentLROPoller],
+    integrator: AzureDocIntelIntegrator,
+    timeout: float | None,
+    *,
+    config: PyPdfToTextConfig | None = None,
+) -> dict[str, OCRResult]:
+    """Collective wait via add_done_callback + threading.Event.
+    On budget exceeded: set cancel_event on remaining pollers, wait
+    _BUDGET_GRACE_SECONDS for late callbacks, synthesize 'OCR batch budget exceeded'
+    for any still missing."""
+```
+
+#### `CancellablePolling` — subclass of `LROBasePolling`
+
+```python
+class CancellablePolling(LROBasePolling):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cancel_event = threading.Event()
+
+    def _delay(self) -> None:
+        # Interruptible sleep
+        self.cancel_event.wait(self._extract_delay())
+
+    def finished(self) -> bool:
+        return self.cancel_event.is_set() or super().finished()
+```
+
+Passed via `client.begin_analyze_document(..., polling=CancellablePolling(lro_delay))`. Brittleness note: depends on `_delay`, `_extract_delay`, and `finished` being stable in `LROBasePolling`. A canary test in `tests/test_cancellable_polling.py` will fail loudly if the SDK refactors these.
+
+#### `ExtractedPage` — one new optional field
+
+```python
+@dataclass
+class ExtractedPage:
+    # ... existing fields unchanged ...
+    ocr_error: str | None = None   # NEW: set when OCR was attempted and failed; None otherwise
+```
+
+On failure, `text` stays `""`, `source` stays `"embedded"`, `azure_page` stays `None`. Callers can detect failure via `if ext_pg.ocr_error: ...`.
+
+#### `PdfExtract` — new attribute, new internal apply
+
+```python
+class PdfExtract:
+    ocr_result: OCRResult | None = None   # NEW public attribute, set after ocr() runs
+
+    def ocr(self, azure: AzureDocIntelIntegrator = AZURE_READ):
+        """Default integrator is the canonical singleton."""
+        if not self._should_ocr(): return
+        poller = azure.submit(self.body, self.ocr_page_idxs, pdf_name=self.pdf_name, config=self.config)
+        if poller is None: return                  # no client configured — same as today
+        result = azure.await_one(poller, pdf_name=self.pdf_name, config=self.config)
+        self._apply_ocr_result(result)
+
+    def _apply_ocr_result(self, result: OCRResult) -> None:
+        """Internal: stash result, update ExtractedPages, apply rotations, set ocr_error on failure."""
+```
+
+The old `self._azure.config = self.config` mutation (currently at line 302-303) is removed — config is passed per-call.
+
+#### `PdfExtractBatch._perform_batch_ocr` — three serial phases
+
+```python
+def _perform_batch_ocr(self):
+    ocr_pdfs = {name: ext for name, ext in self.pdf_extracts.items() if <OCR triggered>}
+    if not ocr_pdfs: return
+    # Phase 1: submit all
+    pollers = {
+        name: AZURE_READ.submit(ext.body, ext.ocr_page_idxs, pdf_name=name, config=self.config)
+        for name, ext in ocr_pdfs.items()
+    }
+    # Drop entries where submit returned None (no client)
+    pollers = {name: p for name, p in pollers.items() if p is not None}
+    # Phase 2: collective wait
+    results = await_all(pollers, AZURE_READ, timeout=self.config.AZURE_DOCINTEL_TIMEOUT, config=self.config)
+    # Phase 3: apply
+    for name, ext in ocr_pdfs.items():
+        if name in results:
+            ext._apply_ocr_result(results[name])
+```
+
+The existing `ThreadPoolExecutor` for OCR is removed. The `ThreadPoolExecutor` for `_pull_s3_parallel` remains untouched.
+
+#### `_config.py` — one new field
+
+```python
+AZURE_CLIENT_POOL_MAXSIZE: int = 20
+"""urllib3 connection pool size for the shared DocumentIntelligenceClient.
+Default sized for MAX_WORKERS=10 with headroom. Increase if running larger batches."""
+```
+
+### Data flow
+
+#### Single-PDF OCR
+
+```text
+caller → PdfExtract.ocr(AZURE_READ)
+  → AZURE_READ.submit(pdf, pages, config=self.config)
+      → client = client_for(config)            [cached by (endpoint, key)]
+      → poller = client.begin_analyze_document(..., polling=CancellablePolling(...))
+      → return poller
+  → AZURE_READ.await_one(poller, config=self.config)
+      → try: raw = poller.result(config.AZURE_DOCINTEL_TIMEOUT)
+      → on timeout: poller._polling_method.cancel_event.set(); raw = None; error = "OCR timeout: ..."
+      → on AzureError: error = "OCR failed: {type}: {msg}"
+      → build OCRResult(pdf_name, config, raw, pages, error)
+      → _thread_local.last_result = raw or AnalyzeResult({})
+      → _thread_local.ocr_result = result
+      → return result
+  → PdfExtract._apply_ocr_result(result)
+      → if result.succeeded: populate pages, source="OCR", handwritten_ratio, azure_page
+      → else: set ocr_error on every affected page
+      → self.ocr_result = result
+```
+
+A caller doing `pdf_text_pages(...)` then `AZURE_READ.last_result` (deprecated) sees the raw result for their thread, matching today's behavior exactly.
+
+#### Batch OCR
+
+```text
+PdfExtractBatch.extract_all()
+  → _extract_embedded_text()    [serial, _batch_mode=True suppresses per-PDF OCR]
+  → _perform_batch_ocr()
+      → Phase 1: serial submit, one HTTP POST per PDF → dict[name, poller]
+      → Phase 2: await_all(pollers, AZURE_READ, timeout, config)
+          → for each poller: poller.add_done_callback(lambda p, n=name: _on_done(n, p))
+          → wait on threading.Event (set when all callbacks fire OR overall timeout)
+          → if timeout: for each remaining poller: cancel_event.set()
+          → wait _BUDGET_GRACE_SECONDS for late callbacks
+          → for any still missing: synthesize OCRResult(error="OCR batch budget exceeded...")
+          → return dict[name, OCRResult]
+      → Phase 3: serial apply, ext._apply_ocr_result(results[name])
+```
+
+No worker thread pool. SDK daemon poll threads do the actual waiting; one fan-in `Event` consolidates the wait.
+
+### Failure semantics
+
+| Failure | Behavior |
+| --- | --- |
+| OCR timeout (`poller.result` returns None) | `OCRResult(error="OCR timeout: poller returned no analyzeResult after Ns")`. ExtractedPage.ocr_error set on every affected page. No exception. |
+| Azure HTTP / `AzureError` | `OCRResult(error="OCR failed: {type}: {msg}")`. Same downstream as timeout. |
+| Response succeeded but `pages` empty | `OCRResult(error="OCR failed: empty result (analyzeResult.pages was empty)")` |
+| No client configured (missing endpoint/key) | `submit()` returns `None`. `ocr()` early-returns. ocr_error *not* set (same as today's "never attempted"). Logged at ERROR. |
+| Batch: overall timeout with N pending | Pending pollers' `cancel_event.set()` → poll loop exits within ~ms → callback fires (may capture lucky-race late result) or `OCRResult(error="OCR batch budget exceeded after Ns")` is synthesized. Daemon threads terminate cleanly. |
+| Programmer error (wrong types, malformed pages list) | Raises `TypeError` / `ValueError`. Not caught. |
+| Deprecated API access | `DeprecationWarning` once per call site (Python's default filter dedupes by `(module, lineno)`). |
+
+**No new exception types are exported.** Callers detect failure via `ocr_result.error is not None` or `ext_pg.ocr_error is not None`.
+
+#### Error string conventions
+
+`OCRResult.error` and `ExtractedPage.ocr_error` use the grammar `OCR <verb>: <detail>` so log/structured filtering is straightforward:
+
+```text
+"OCR timeout: poller returned no analyzeResult after 60s"
+"OCR failed: HttpResponseError(404) Resource not found"
+"OCR failed: AzureError <msg>"
+"OCR failed: empty result (analyzeResult.pages was empty)"
+"OCR batch budget exceeded after 60s (pdf still pending)"
+```
+
+#### Logging changes
+
+Today's misleading INFO line ("X pages OCR'd successfully") fires unconditionally after `poller.result()` returns. Replaced with conditional logging:
+
+```python
+if result.succeeded:
+    logger.info("[%s] OCR completed: %d pages rendered.", pdf_name, len(result.pages))
+else:
+    logger.error("[%s] OCR did not complete: %s", pdf_name, result.error)
+```
+
+The "Creating fixed width pages" phrasing is dropped — implementation detail, and misleading because the pages are already built when the log fires.
+
+### Back-compat and deprecation plan
+
+`AZURE_READ` and the integrator's public methods are exported in `__all__` and used by `pdf_text_pages` (which the docstring warns is "NOT thread safe"). The deprecation surfaces:
+
+| Surface | Replacement | Back-compat behavior |
+| --- | --- | --- |
+| `AZURE_READ.last_result` (attribute) | `PdfExtract.ocr_result.raw` or `OCRResult.raw` | `@property` backed by `threading.local()`. Each thread sees its own most-recent OCR's raw `AnalyzeResult`. Strict improvement over today's race for multi-threaded callers. Empty `AnalyzeResult({})` sentinel returned when no OCR has run on this thread. Emits `DeprecationWarning`. |
+| `AzureDocIntelIntegrator.handwritten_ratio(idx)` | `OCRResult.handwritten_ratio(idx)` | Reads thread-local `ocr_result` and delegates. Emits `DeprecationWarning`. |
+| `AzureDocIntelIntegrator.rotation_degrees(idx)` | `OCRResult.rotation_degrees(idx)` | Same. |
+| `AzureDocIntelIntegrator.page_at_index(idx)` | `OCRResult.page_at_index(idx)` | Same. |
+| `AzureDocIntelIntegrator.reset()` | (no replacement needed) | Clears thread-local. Emits `DeprecationWarning`. |
+
+`AZURE_READ` itself is **not** deprecated — it's promoted to the canonical shared integrator. `pdf_text_pages` continues to use it as today.
+
+Removal target: one minor version after the rewrite ships (e.g. 0.4 introduces deprecation, 0.5 removes the back-compat layer). Not part of this spec; raised at release-planning time.
+
+### `ExtractedPage.source` semantics
+
+`source` stays `Literal["embedded", "OCR"]`. On OCR failure, source remains `"embedded"` (the text *is* empty embedded content — OCR didn't succeed). Callers detect failure via `ocr_error`. Rationale: keeping the Literal narrow avoids forcing every consumer of `source` to handle a new variant.
+
+### Public API delta (additive only)
+
+- `pypdftotext.OCRResult` — new class
+- `pypdftotext.PdfExtract.ocr_result: OCRResult | None` — new attribute
+- `pypdftotext.ExtractedPage.ocr_error: str | None` — new field (default `None`, preserves equality semantics for fixtures)
+- `pypdftotext.PyPdfToTextConfig.AZURE_CLIENT_POOL_MAXSIZE: int = 20` — new setting
+- `PdfExtract.ocr(azure)` — default for `azure` parameter changes from "construct a fresh integrator" to `AZURE_READ`. Behavior identical for callers passing explicit `azure=`.
+
+No removals. No type signature changes on existing public methods.
+
+---
+
+## Testing strategy
+
+Coverage-based, not case-enumerated: tests aim to exercise distinct behaviors and branches, with parametrization where variants share assertion shape. Two named regression tests are kept dedicated (timeout-None and batch-budget-exceeded) because they document specific bugs/edge cases the rewrite fixes.
+
+### Doctest (in docstrings)
+
+- `OCRResult.succeeded`
+- `OCRResult.page_at_index`
+
+### New `tests/test_azure_docintel_integrator.py`
+
+- `test_submit_returns_poller_when_client_available` — happy-path submit; mocked client returns `Mock(spec=AnalyzeDocumentLROPoller)`.
+- `test_await_one_success` — fixture `AnalyzeResult` → `OCRResult.succeeded is True`, pages rendered. Thread-local update is implicit (verified separately).
+- **`test_await_one_timeout_yields_error_result`** — regression test for the original bug. Mock `poller.result()` to return `None`. Assert `OCRResult.error.startswith("OCR timeout")`, `raw is None`, `pages == []`.
+- `test_await_one_error_paths` *(parametrized)* — `HttpResponseError` raised by `poller.result()`, `AnalyzeResult(pages=[])`. Each variant asserts the appropriate `OCRResult.error` prefix.
+- `test_thread_local_isolation_across_threads` — two `threading.Thread`s with distinct mocked results; each sees its own via the deprecated `AZURE_READ.last_result`. Regression test for P4 contamination fix.
+- `test_deprecation_warnings_and_back_compat` — accesses each deprecated surface (`last_result`, `handwritten_ratio`, `rotation_degrees`, `page_at_index`, `reset`); asserts `DeprecationWarning` is emitted AND that the return value matches the equivalent `OCRResult` method (back-compat shim correctness).
+- `test_client_for` *(parametrized)* — caching by `(endpoint, key)` (same → identical, different → new), missing creds → `None`, `AZURE_CLIENT_POOL_MAXSIZE` is forwarded to transport construction.
+
+### New `tests/test_cancellable_polling.py` (SDK canary)
+
+- `test_cancel_event_terminates_polling` — construct `CancellablePolling`, call `_delay()` in a thread, `cancel_event.set()` from main, assert thread returns within 100ms AND `finished()` returns `True` afterward. Doubles as the SDK canary: if `_delay`/`finished`/`_extract_delay` go away in a future `azure-core`, this test fails to construct or run.
+
+### New `tests/test_await_all.py`
+
+- `test_await_all_collects_all_results` *(parametrized: N=0, N=1, N=3)* — pollers fire their done callbacks; `await_all` returns a dict with one `OCRResult(succeeded=True)` per name.
+- **`test_await_all_synthesizes_budget_exceeded_on_timeout`** — M of N pollers don't complete by the budget. Remaining pollers' `cancel_event` gets set; their callbacks may fire during the grace window (lucky-race covered: that variant asserts the real result wins) or get synthesized as `OCRResult(error="OCR batch budget exceeded...")`. Regression test for the cleanup path.
+
+### Extensions to `tests/test_pdf_extract.py`
+
+- `test_ocr_end_to_end` *(parametrized: success / timeout / azure-error)* — `PdfExtract.ocr()` invoked with a mocked azure integrator. For success: assert `ExtractedPage.text` populated, `source == "OCR"`, `handwritten_ratio` set, `ocr_result.succeeded is True`, no false INFO log. For failure variants: assert `ocr_error` set on every affected page, `text == ""`, `source == "embedded"`, ERROR log present, no INFO success log. Also verifies the default `azure=AZURE_READ` by invoking `ocr()` with no argument and asserting AZURE_READ's thread-local was populated.
+
+### Extensions to `tests/test_batch.py`
+
+- `test_perform_batch_ocr_uses_azure_read_no_threadpool` — patch `AZURE_READ.submit` and the module-level `await_all`; assert both are called, AND assert `ThreadPoolExecutor` is NOT instantiated inside `_perform_batch_ocr` (scoped — `_pull_s3_parallel` still uses one and is unaffected).
+- `test_partial_failure_does_not_crash_batch` — `await_all` returns a mix of successful and error `OCRResult`s; batch completes; failed PDFs have `ocr_error` set; others have populated text.
+
+Existing tests in the suite (including the `samples/all70th.bin` fixture-based ones) must continue to pass without modification. This is verified by running the full suite at CI time, not via a dedicated test entry.
+
+### Manual / smoke verification (not in CI)
+
+```bash
+<PREFIX> pytest tests/ -v
+<PREFIX> pytest tests/test_azure_docintel_integrator.py tests/test_cancellable_polling.py tests/test_await_all.py -v
+<PREFIX> pyright pypdftotext/
+<PREFIX> ruff check pypdftotext/
+<PREFIX> ruff format --check pypdftotext/
+<PREFIX> pytest --doctest-modules pypdftotext/
+```
+
+---
+
+## Migration / rollout
+
+1. Land on a feature branch with all changes in one PR. Diff is medium (~600 lines new, ~150 lines changed). Single reviewable unit.
+2. Existing `tests/` directory exercises real fixtures (`samples/all70th.bin` is a pickled `AnalyzeResult`); the new flow must produce byte-identical output for the success path. Add the new tests, ensure existing tests pass unchanged.
+3. Release as a minor version bump (0.3.8 → 0.4.0). Document deprecations in the changelog.
+4. Schedule deprecation-layer removal for the *next* minor (0.5.0). Out of scope for this spec.
+
+---
+
+## Out of scope / deferred
+
+- **P3 thread-safety** (multi-thread sharing one `PdfExtract`). `PdfReader`/`PdfWriter` are not thread-safe today, documented in CLAUDE.md. Revisit after this rewrite lands. Saved to project auto-memory as `project_p3_followup`.
+- **Asyncio core.** Considered and declined. Conflict with caller event loops outweighs the efficiency gain over sync submit-and-await.
+- **Continuation-token crash recovery.** Feasible but a separate concern. `OCRResult` does not currently expose `continuation_token`; it could be added later as an optional field without breaking anything.
+- **Cancelling Azure-side processing.** No API path exists; we can only stop waiting locally. Cancelled-but-still-processing operations on Azure run to completion and count against quota, same as today's "timed out but kept polling" behavior.
+- **Removing the deprecation layer.** Planned for one minor version after this rewrite ships.
+
+---
+
+## Open questions
+
+None remaining. All design decisions resolved during brainstorming:
+
+- Scope: submit-and-await + `OCRResult` (broader than surgical fix, narrower than asyncio rewrite). Resolved.
+- Failure model: soft-fail + `ExtractedPage.ocr_error` attribute. Resolved.
+- `AZURE_READ` future: promoted to canonical shared instance with thread-local back-compat. Resolved.
+- `OCRResult` publicity: public, exported in `__all__`. Resolved.
+- Cancellation: `CancellablePolling` subclass; accept SDK-private-API brittleness, covered by canary test. Resolved.
+- Per-call config override: via `config=` kwarg on `submit`/`await_one`/`await_all`. Resolved.
+
+---
+
+## Appendix: Patterns table (P1–P4) for quick reference
+
+See "Cross-thread contamination patterns" above. The TL;DR:
+
+- **P1 (multi-process)** — safe, no change
+- **P2 (one PdfExtract per thread)** — safe, no change
+- **P3 (shared PdfExtract across threads)** — unsafe today, **deferred**
+- **P4 (shared AzureDocIntelIntegrator across threads)** — unsafe today, **fixed by this rewrite** via per-call `OCRResult` value type

--- a/pypdftotext/__init__.py
+++ b/pypdftotext/__init__.py
@@ -13,6 +13,7 @@ from ._config import PyPdfToTextConfig, PyPdfToTextConfigOverrides, constants
 from .azure_docintel_integrator import AZURE_READ
 from .batch import PdfExtractBatch
 from .extracted_page import ExtractedPage
+from .ocr_result import OCRResult
 from .pdf_extract import AllPagesRemovedError, PdfExtract
 
 logger = logging.getLogger(__name__)
@@ -105,6 +106,7 @@ __all__ = [
     "pdf_text_pages",
     "pdf_text_page_lines",
     "ExtractedPage",
+    "OCRResult",
     "PyPdfToTextConfig",
     "PyPdfToTextConfigOverrides",
     "AllPagesRemovedError",

--- a/pypdftotext/__init__.py
+++ b/pypdftotext/__init__.py
@@ -1,6 +1,6 @@
 """Extract text from pdf pages from codebehind or Azure OCR as required"""
 
-__version__ = "0.3.8"
+__version__ = "0.4.0"
 
 import io
 import logging

--- a/pypdftotext/_cancellable_polling.py
+++ b/pypdftotext/_cancellable_polling.py
@@ -1,0 +1,48 @@
+"""Internal subclass of LROBasePolling that supports cooperative cancellation.
+
+`LROPoller.result(timeout)` does not raise on timeout; it returns whatever
+`_polling_method.resource()` produces given the most recent polled response.
+That leaves the SDK's daemon polling thread running indefinitely, even when
+the caller no longer cares about the result.
+
+`CancellablePolling` adds a `cancel_event` Event. When set, the next call to
+`_delay()` returns immediately and `finished()` reports True, causing the
+polling loop in `LROBasePolling._poll()` to exit cleanly. The done callbacks
+then fire (possibly capturing a just-completed result; see await_one in
+azure_docintel_integrator), and the daemon thread terminates.
+
+Brittleness note: this subclass depends on the private `_delay`,
+`_extract_delay`, and `finished` methods of LROBasePolling. The test in
+tests/test_cancellable_polling.py is a canary that will fail loudly if those
+methods are refactored in a future azure-core version.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from azure.core.polling.base_polling import LROBasePolling
+
+
+class CancellablePolling(LROBasePolling):
+    """LROBasePolling with cooperative cancellation via a threading.Event."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cancel_event = threading.Event()
+
+    def _delay(self) -> None:
+        """Sleep for the inter-poll delay, returning immediately if cancelled.
+
+        Overrides ``LROBasePolling._delay``, which calls
+        ``self._transport.sleep(delay)`` unconditionally. ``Event.wait(timeout)``
+        gives us the same blocking behavior but returns early when the event is
+        set, enabling cancellation within milliseconds.
+        """
+        self.cancel_event.wait(self._extract_delay())
+
+    def finished(self) -> bool:
+        """True when cancelled OR when the polled operation reports done."""
+        if self.cancel_event.is_set():
+            return True
+        return super().finished()

--- a/pypdftotext/_config.py
+++ b/pypdftotext/_config.py
@@ -17,6 +17,7 @@ class PyPdfToTextConfigOverrides(TypedDict, total=False):
     """
 
     INHERIT_CONSTANTS: bool
+    AZURE_CLIENT_POOL_MAXSIZE: int
     AZURE_DOCINTEL_ENDPOINT: str
     AZURE_DOCINTEL_SUBSCRIPTION_KEY: str
     AZURE_DOCINTEL_AUTO_CLIENT: bool
@@ -79,6 +80,10 @@ class _ConfigMixIn:
     """How long to wait for Azure OCR results before timing out. Default is 60."""
     AZURE_DOCINTEL_MODEL: Literal["prebuilt-read", "prebuilt-layout"] = "prebuilt-read"
     """The value to use for the 'model_id' parameter when calling the Azure API"""
+    AZURE_CLIENT_POOL_MAXSIZE: int = 20
+    """urllib3 connection pool size for the shared DocumentIntelligenceClient.
+    Default sized for MAX_WORKERS=10 with headroom. Increase if running batches
+    that submit more concurrent OCR requests than this value."""
     DISABLE_OCR: bool = False
     """Set to True to disable all OCR operations and return 'code behind' text
     only."""

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -5,6 +5,7 @@ import logging
 import os
 import threading
 import warnings
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from azure.ai.documentintelligence import AnalyzeDocumentLROPoller, DocumentIntelligenceClient
@@ -67,6 +68,85 @@ def client_for(config: PyPdfToTextConfig) -> DocumentIntelligenceClient | None:
                 config.AZURE_CLIENT_POOL_MAXSIZE,
             )
         return client
+
+
+_BUDGET_GRACE_SECONDS: float = 5.0
+"""How long await_all waits after signalling cancellation for late callbacks
+to fire before synthesizing 'budget exceeded' results. Internal tuning
+constant; not configurable."""
+
+
+def await_all(
+    pollers: "Mapping[str, AnalyzeDocumentLROPoller]",
+    integrator: "AzureDocIntelIntegrator",
+    timeout: float | None,
+    *,
+    config: PyPdfToTextConfig | None = None,
+) -> dict[str, OCRResult]:
+    """Collectively wait for many pollers and return one OCRResult per name.
+
+    Registers a done-callback on each poller. The callback builds an OCRResult
+    via ``integrator.await_one`` (which returns near-instantly because the
+    poller is already done when the callback fires) and records it in a shared
+    dict. Blocks until either all callbacks have fired or the overall
+    ``timeout`` elapses.
+
+    On timeout: sets ``cancel_event`` on every poller whose result is still
+    missing, waits up to ``_BUDGET_GRACE_SECONDS`` for late callbacks
+    (lucky-race window), then synthesizes
+    ``OCRResult(error="OCR batch budget exceeded ...")`` for any still missing.
+
+    Args:
+        pollers: dict mapping pdf_name to poller.
+        integrator: the integrator whose await_one is used inside the
+            callback. Its ``_thread_local`` is updated for the LAST callback
+            to fire (race outcome; matches the "undefined in batch context"
+            semantics for AZURE_READ.last_result).
+        timeout: overall budget in seconds. None means wait indefinitely.
+        config: optional per-batch config override for ``await_one``.
+
+    Returns:
+        dict mapping pdf_name to OCRResult. Never raises.
+    """
+    cfg = config or integrator.config
+    results: dict[str, OCRResult] = {}
+    done_event = threading.Event()
+    lock = threading.Lock()
+    total = len(pollers)
+    if total == 0:
+        return results
+
+    def _on_done(name: str, poller) -> None:
+        result = integrator.await_one(poller, pdf_name=name, config=cfg)
+        with lock:
+            if name not in results:
+                results[name] = result
+                if len(results) == total:
+                    done_event.set()
+
+    for name, poller in pollers.items():
+        # Capture name via default arg to avoid late-binding closure bug.
+        poller.add_done_callback(lambda p, n=name: _on_done(n, p))
+
+    if not done_event.wait(timeout):
+        pending_names = [n for n in pollers if n not in results]
+        for n in pending_names:
+            polling_method = getattr(pollers[n], "_polling_method", None)
+            cancel_event = getattr(polling_method, "cancel_event", None)
+            if cancel_event is not None:
+                cancel_event.set()
+        done_event.wait(_BUDGET_GRACE_SECONDS)
+        with lock:
+            for n in pollers:
+                if n not in results:
+                    results[n] = OCRResult(
+                        pdf_name=n,
+                        config=cfg,
+                        raw=None,
+                        pages=[],
+                        error=(f"OCR batch budget exceeded after {timeout}s (pdf still pending)"),
+                    )
+    return results
 
 
 @dataclass

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -13,6 +13,7 @@ from azure.core.pipeline.transport import RequestsTransport
 from tqdm import tqdm
 
 from . import layout
+from ._cancellable_polling import CancellablePolling
 from ._config import PyPdfToTextConfig
 
 logger = logging.getLogger(__name__)
@@ -107,6 +108,57 @@ class AzureDocIntelIntegrator:
     def reset(self):
         """Clear last_result from previous run."""
         self.last_result = AnalyzeResult({})
+
+    def submit(
+        self,
+        pdf: bytes,
+        pages: list[int],
+        pdf_name: str = "",
+        *,
+        config: PyPdfToTextConfig | None = None,
+    ) -> AnalyzeDocumentLROPoller | None:
+        """Submit pages for OCR without blocking.
+
+        Returns a poller that can be passed to ``await_one`` (or collected in
+        a dict and passed to ``await_all``) for later result retrieval. Uses
+        ``CancellablePolling`` internally so the eventual wait can be
+        cancelled cleanly on timeout.
+
+        Args:
+            pdf: bytes of the PDF to OCR.
+            pages: 0-based page indices to OCR. Converted to the SDK's
+                1-based ``pages`` string parameter internally.
+            pdf_name: optional identifier for log correlation.
+            config: optional per-call override. Defaults to ``self.config``.
+
+        Returns:
+            A poller, or None when no client could be constructed (missing
+            credentials).
+        """
+        cfg = config or self.config
+        client = client_for(cfg)
+        if client is None:
+            logger.error(
+                "[%s] Cannot submit OCR: no client available "
+                "(check AZURE_DOCINTEL_ENDPOINT and AZURE_DOCINTEL_SUBSCRIPTION_KEY)",
+                pdf_name or "<unnamed>",
+            )
+            return None
+        prefix = f"[{pdf_name}] " if pdf_name else ""
+        logger.info(
+            "%sSubmitting %d pages for OCR (pdf bytes=%d)",
+            prefix,
+            len(pages),
+            len(pdf),
+        )
+        polling = CancellablePolling(client._config.polling_interval)
+        poller = client.begin_analyze_document(
+            model_id=cfg.AZURE_DOCINTEL_MODEL,
+            body=io.BytesIO(pdf),
+            pages=",".join(str(pg + 1) for pg in pages),
+            polling=polling,
+        )
+        return poller
 
     def ocr_pages(self, pdf: bytes, pages: list[int], pdf_name: str = "") -> list[str]:
         """

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -12,7 +12,6 @@ from azure.ai.documentintelligence.models import AnalyzeResult, DocumentPage
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import AzureError, HttpResponseError
 from azure.core.pipeline.transport import RequestsTransport
-from tqdm import tqdm
 
 from . import layout
 from ._cancellable_polling import CancellablePolling
@@ -118,32 +117,18 @@ class AzureDocIntelIntegrator:
         return getattr(self._thread_local, "last_result", AnalyzeResult({}))
 
     def create_client(self) -> bool:
+        """Create or retrieve the cached DocumentIntelligenceClient.
+
+        Returns True if a client is available (newly cached or pre-existing),
+        False otherwise. The actual client object is stored on
+        ``self.client`` for back-compat with any callers that introspect it.
         """
-        Create an Azure DocumentIntelligenceClient based on current global
-        constants and env var settings.
-
-        The following may be set via env var prior to module import OR set via
-        the corresponding self.config.<ENV_VARIABLE_NAME> global constant after
-        module import.
-
-        Constants/Environment Variables:
-            AZURE_DOCINTEL_ENDPOINT: Azure Document Intelligence Instance Endpoint URL.
-            AZURE_DOCINTEL_SUBSCRIPTION_KEY: Azure Document Intelligence Subscription Key.
-
-        Returns:
-            bool: True if client was created successfully. False otherwise.
-        """
-        endpoint = os.getenv("AZURE_DOCINTEL_ENDPOINT") or self.config.AZURE_DOCINTEL_ENDPOINT
-        key = (
-            os.getenv("AZURE_DOCINTEL_SUBSCRIPTION_KEY")
-            or self.config.AZURE_DOCINTEL_SUBSCRIPTION_KEY
-        )
-        if endpoint and key:
-            self.client = DocumentIntelligenceClient(endpoint, AzureKeyCredential(key))
-            logger.info("Azure OCR Client Created: endpoint='%s'", endpoint)
-            return True
-        logger.error("Failed to create Azure OCR Client at endpoint='%s'", endpoint)
-        return False
+        self.client = client_for(self.config)
+        if self.client is None:
+            endpoint = os.getenv("AZURE_DOCINTEL_ENDPOINT") or self.config.AZURE_DOCINTEL_ENDPOINT
+            logger.error("Failed to obtain Azure OCR Client at endpoint='%s'", endpoint)
+            return False
+        return True
 
     def submit(
         self,
@@ -172,7 +157,9 @@ class AzureDocIntelIntegrator:
             credentials).
         """
         cfg = config or self.config
-        client = client_for(cfg)
+        # Prefer the cached/credential-based client; fall back to self.client so
+        # callers that assign a pre-built (or mock) client directly still work.
+        client = client_for(cfg) or self.client
         if client is None:
             logger.error(
                 "[%s] Cannot submit OCR: no client available "
@@ -273,58 +260,27 @@ class AzureDocIntelIntegrator:
             logger.error("%sOCR did not complete: %s", prefix, result.error)
         return result
 
-    def ocr_pages(self, pdf: bytes, pages: list[int], pdf_name: str = "") -> list[str]:
-        """
-        Read the text from supplied pdf page indices.
+    def ocr_pages(
+        self,
+        pdf: bytes,
+        pages: list[int],
+        pdf_name: str = "",
+    ) -> list[str]:
+        """Submit pages for OCR and wait for the result.
 
-        Args:
-            pdf: bytes of a pdf file
-            pages: list of pdf page indices to OCR
-            pdf_name: optional identifier included in log messages for parallel tracing
-
-        Returns:
-            list[str]: list of strings containing structured text extracted
-                from each supplied page index.
+        Thin wrapper over ``submit`` + ``await_one``. Returns the rendered
+        fixed-width page strings, or an empty list on failure (failure is
+        also logged at ERROR; see ``await_one`` for details).
         """
         if self.config.AZURE_DOCINTEL_AUTO_CLIENT and self.client is None:
-            self.create_client()
-        if self.client is None:
-            logger.error(
-                "Azure OCR API not available. Did you create a client? Returning empty list."
-            )
+            # Eager create-and-cache via client_for so the legacy `self.client`
+            # attribute is populated for any external introspection.
+            self.client = client_for(self.config)
+        poller = self.submit(pdf, pages, pdf_name=pdf_name)
+        if poller is None:
             return []
-        assert self.client is not None
-        prefix = f"[{pdf_name}] " if pdf_name else ""
-        logger.info("%sSending pdf of %s bytes for OCR of %s pages.", prefix, len(pdf), len(pages))
-        poller: AnalyzeDocumentLROPoller = self.client.begin_analyze_document(
-            model_id=self.config.AZURE_DOCINTEL_MODEL,
-            body=io.BytesIO(pdf),
-            pages=",".join(str(pg + 1) for pg in pages),
-        )
-        # (Temporary: Task 11 swaps ocr_pages to a thin wrapper around submit+await_one.)
-        self._thread_local.last_result = poller.result(self.config.AZURE_DOCINTEL_TIMEOUT)
-        logger.info(
-            "%s%s pages OCR'd successfully. Creating fixed width pages.", prefix, len(pages)
-        )
-        ocr_pbar = tqdm(
-            self._thread_local.last_result.pages,
-            desc="Processing OCR results...",
-            disable=self.config.DISABLE_PROGRESS_BAR,
-            position=self.config.PROGRESS_BAR_POSITION,
-            leave=None,
-        )
-        results: list[str] = [
-            layout.fixed_width_page(doc_page, self.config) for doc_page in ocr_pbar
-        ]
-        # Populate ocr_result so deprecated wrappers (handwritten_ratio, rotation_degrees,
-        # page_at_index) can delegate to OCRResult instead of reading last_result directly.
-        self._thread_local.ocr_result = OCRResult(
-            pdf_name=pdf_name,
-            config=self.config,
-            raw=self._thread_local.last_result,
-            pages=results,
-        )
-        return results
+        result = self.await_one(poller, pdf_name=pdf_name)
+        return result.pages
 
     def handwritten_ratio(
         self,

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -85,22 +85,25 @@ def await_all(
 ) -> dict[str, OCRResult]:
     """Collectively wait for many pollers and return one OCRResult per name.
 
-    Registers a done-callback on each poller. The callback builds an OCRResult
-    via ``integrator.await_one`` (which returns near-instantly because the
-    poller is already done when the callback fires) and records it in a shared
-    dict. Blocks until either all callbacks have fired or the overall
-    ``timeout`` elapses.
+    Registers a done-callback on each poller. The callback only records
+    completion (sets an Event when all are done). The coordinating thread
+    then harvests results via ``integrator.await_one`` — this must happen
+    on the coordinator thread, NOT inside the callback, because Azure SDK
+    callbacks fire on the poller's own daemon thread and calling
+    ``poller.result()`` from that thread triggers
+    ``RuntimeError: cannot join current thread``.
 
     On timeout: sets ``cancel_event`` on every poller whose result is still
     missing, waits up to ``_BUDGET_GRACE_SECONDS`` for late callbacks
     (lucky-race window), then synthesizes
-    ``OCRResult(error="OCR batch budget exceeded ...")`` for any still missing.
+    ``OCRResult(error="OCR batch budget exceeded ...")`` for any still
+    missing.
 
     Args:
         pollers: dict mapping pdf_name to poller.
-        integrator: the integrator whose await_one is used inside the
-            callback. Its ``_thread_local`` is updated for the LAST callback
-            to fire (race outcome; matches the "undefined in batch context"
+        integrator: the integrator whose await_one is used during the
+            harvest phase. Its ``_thread_local`` is updated for the LAST
+            harvest to complete (matches the "undefined in batch context"
             semantics for AZURE_READ.last_result).
         timeout: overall budget in seconds. None means wait indefinitely.
         config: optional per-batch config override for ``await_one``.
@@ -112,40 +115,60 @@ def await_all(
     results: dict[str, OCRResult] = {}
     done_event = threading.Event()
     lock = threading.Lock()
+    completed: set[str] = set()
     total = len(pollers)
     if total == 0:
         return results
 
-    def _on_done(name: str, poller) -> None:
-        result = integrator.await_one(poller, pdf_name=name, config=cfg)
+    def _on_done(name: str) -> None:
+        # CRITICAL: do NOT call poller.result() / await_one() here. This
+        # callback fires on the SDK's daemon polling thread, which would
+        # deadlock or raise on Thread.join(self). Just signal completion;
+        # the coordinator thread does the result extraction.
         with lock:
-            if name not in results:
-                results[name] = result
-                if len(results) == total:
+            if name not in completed:
+                completed.add(name)
+                if len(completed) == total:
                     done_event.set()
 
     for name, poller in pollers.items():
-        # Capture name via default arg to avoid late-binding closure bug.
-        poller.add_done_callback(lambda p, n=name: _on_done(n, p))
+        # SDK passes the polling method to the callback; we ignore it via _pm.
+        poller.add_done_callback(lambda _pm, n=name: _on_done(n))
 
+    # Phase 1: wait for all callbacks to fire (or timeout).
     if not done_event.wait(timeout):
-        pending_names = [n for n in pollers if n not in results]
+        # Budget elapsed. Cancel pending pollers and wait briefly for late
+        # callbacks (lucky-race window).
+        with lock:
+            pending_names = [n for n in pollers if n not in completed]
         for n in pending_names:
             polling_method = getattr(pollers[n], "_polling_method", None)
             cancel_event = getattr(polling_method, "cancel_event", None)
             if cancel_event is not None:
                 cancel_event.set()
         done_event.wait(_BUDGET_GRACE_SECONDS)
-        with lock:
-            for n in pollers:
-                if n not in results:
-                    results[n] = OCRResult(
-                        pdf_name=n,
-                        config=cfg,
-                        raw=None,
-                        pages=[],
-                        error=(f"OCR batch budget exceeded after {timeout}s (pdf still pending)"),
-                    )
+
+    # Phase 2: harvest results on the coordinating thread.
+    # Safe to call poller.result() here because we are NOT the daemon
+    # polling thread; the thread that just finished polling is the one
+    # we're joining, not ourselves.
+    with lock:
+        completed_snapshot = set(completed)
+    for name in pollers:
+        if name in completed_snapshot:
+            results[name] = integrator.await_one(
+                pollers[name],
+                pdf_name=name,
+                config=cfg,
+            )
+        else:
+            results[name] = OCRResult(
+                pdf_name=name,
+                config=cfg,
+                raw=None,
+                pages=[],
+                error=(f"OCR batch budget exceeded after {timeout}s (pdf still pending)"),
+            )
     return results
 
 

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -9,12 +9,14 @@ from dataclasses import dataclass, field
 from azure.ai.documentintelligence import AnalyzeDocumentLROPoller, DocumentIntelligenceClient
 from azure.ai.documentintelligence.models import AnalyzeResult, DocumentPage
 from azure.core.credentials import AzureKeyCredential
+from azure.core.exceptions import AzureError, HttpResponseError
 from azure.core.pipeline.transport import RequestsTransport
 from tqdm import tqdm
 
 from . import layout
 from ._cancellable_polling import CancellablePolling
 from ._config import PyPdfToTextConfig
+from .ocr_result import OCRResult
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +77,11 @@ class AzureDocIntelIntegrator:
 
     config: PyPdfToTextConfig = field(default_factory=PyPdfToTextConfig)
     client: DocumentIntelligenceClient | None = field(default=None, init=False, repr=False)
-    last_result: AnalyzeResult = field(default_factory=lambda: AnalyzeResult({}), init=False)
+    _thread_local: threading.local = field(
+        default_factory=threading.local,
+        init=False,
+        repr=False,
+    )
 
     def create_client(self) -> bool:
         """
@@ -107,7 +113,7 @@ class AzureDocIntelIntegrator:
 
     def reset(self):
         """Clear last_result from previous run."""
-        self.last_result = AnalyzeResult({})
+        self._thread_local.last_result = AnalyzeResult({})
 
     def submit(
         self,
@@ -160,6 +166,83 @@ class AzureDocIntelIntegrator:
         )
         return poller
 
+    def await_one(
+        self,
+        poller: AnalyzeDocumentLROPoller,
+        pdf_name: str = "",
+        *,
+        config: PyPdfToTextConfig | None = None,
+    ) -> OCRResult:
+        """Wait for the given poller to complete and build an OCRResult.
+
+        On timeout, the poller's CancellablePolling.cancel_event is set so
+        the SDK's daemon poll thread terminates cleanly. The returned
+        OCRResult carries error=str when the wait timed out, the SDK raised
+        an AzureError, or the result had zero pages.
+
+        Updates ``self._thread_local`` for deprecated callers of
+        ``self.last_result`` / ``self.handwritten_ratio`` / etc.
+
+        Args:
+            poller: poller previously returned by ``self.submit``.
+            pdf_name: identifier for log correlation; carried into the
+                returned OCRResult.
+            config: optional per-call override. Defaults to ``self.config``.
+
+        Returns:
+            An OCRResult. Never raises on Azure/timeout errors; check
+            ``result.succeeded`` and ``result.error``.
+        """
+        cfg = config or self.config
+        prefix = f"[{pdf_name}] " if pdf_name else ""
+        raw: AnalyzeResult | None
+        error: str | None = None
+        try:
+            raw = poller.result(cfg.AZURE_DOCINTEL_TIMEOUT)
+        except HttpResponseError as e:
+            raw = None
+            error = f"OCR failed: HttpResponseError: {e}"
+        except AzureError as e:
+            raw = None
+            error = f"OCR failed: {type(e).__name__}: {e}"
+        if raw is None and error is None:
+            # poller.result returned None — the timeout-without-exception case.
+            error = (
+                f"OCR timeout: poller returned no analyzeResult after "
+                f"{cfg.AZURE_DOCINTEL_TIMEOUT}s"
+            )
+        if error is not None:
+            # Signal the daemon poll thread to exit. Best-effort: not all
+            # mocked pollers have a CancellablePolling, so guard the access.
+            polling_method = getattr(poller, "_polling_method", None)
+            cancel_event = getattr(polling_method, "cancel_event", None)
+            if cancel_event is not None:
+                cancel_event.set()
+        pages: list[str] = []
+        if raw is not None and not raw.pages:
+            error = error or "OCR failed: empty result (analyzeResult.pages was empty)"
+        elif raw is not None:
+            pages = [layout.fixed_width_page(doc_page, cfg) for doc_page in raw.pages]
+        result = OCRResult(
+            pdf_name=pdf_name,
+            config=cfg,
+            raw=raw,
+            pages=pages,
+            error=error,
+        )
+        # Update thread-local for back-compat consumers.
+        self._thread_local.last_result = raw if raw is not None else AnalyzeResult({})
+        self._thread_local.ocr_result = result
+        if result.succeeded:
+            logger.info(
+                "%sOCR completed: %d pages rendered.",
+                prefix,
+                len(result.pages),
+            )
+        else:
+            logger.error("%sOCR did not complete: %s", prefix, result.error)
+        return result
+
     def ocr_pages(self, pdf: bytes, pages: list[int], pdf_name: str = "") -> list[str]:
         """
         Read the text from supplied pdf page indices.
@@ -188,12 +271,13 @@ class AzureDocIntelIntegrator:
             body=io.BytesIO(pdf),
             pages=",".join(str(pg + 1) for pg in pages),
         )
-        self.last_result = poller.result(self.config.AZURE_DOCINTEL_TIMEOUT)
+        # (Temporary: Task 11 swaps ocr_pages to a thin wrapper around submit+await_one.)
+        self._thread_local.last_result = poller.result(self.config.AZURE_DOCINTEL_TIMEOUT)
         logger.info(
             "%s%s pages OCR'd successfully. Creating fixed width pages.", prefix, len(pages)
         )
         ocr_pbar = tqdm(
-            self.last_result.pages,
+            self._thread_local.last_result.pages,
             desc="Processing OCR results...",
             disable=self.config.DISABLE_PROGRESS_BAR,
             position=self.config.PROGRESS_BAR_POSITION,
@@ -243,7 +327,9 @@ class AzureDocIntelIntegrator:
                 sel.span.length for sel in _selected_page.selection_marks or []
             )
             # finally, we'll ignore newline chars that occur in the page span
-            page_length_reduction += self.last_result.content[page_start:page_end].count("\n")
+            page_length_reduction += self._thread_local.last_result.content[
+                page_start:page_end
+            ].count("\n")
             page_length = page_end - page_start - page_length_reduction
             if page_length <= 0:
                 # whoops! something's wrong. We should probably throw an exception here, but
@@ -262,7 +348,7 @@ class AzureDocIntelIntegrator:
             handwritten_length = sum(
                 (
                     (span.offset + min(span.length, page_end)) - span.offset
-                    for style in (self.last_result.styles or [])
+                    for style in (self._thread_local.last_result.styles or [])
                     if style.is_handwritten
                     and style.confidence >= self.config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT
                     for span in style.spans
@@ -311,7 +397,7 @@ class AzureDocIntelIntegrator:
         if any(
             # find the page at the supplied index and report its angle. otherwise return 0.0.
             (_selected_page := page).page_number == page_index + 1
-            for page in self.last_result.pages
+            for page in self._thread_local.last_result.pages
         ):
             return _selected_page
         # page was not OCR'd. Return None.

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -4,6 +4,7 @@ import io
 import logging
 import os
 import threading
+import warnings
 from dataclasses import dataclass, field
 
 from azure.ai.documentintelligence import AnalyzeDocumentLROPoller, DocumentIntelligenceClient
@@ -83,6 +84,27 @@ class AzureDocIntelIntegrator:
         repr=False,
     )
 
+    def reset(self):
+        """Clear last_result from previous run."""
+        self._thread_local.last_result = AnalyzeResult({})
+
+    @property
+    def last_result(self) -> AnalyzeResult:
+        """DEPRECATED. The raw AnalyzeResult from this thread's most recent
+        await_one call, or AnalyzeResult({}) if no OCR has run on this thread.
+
+        Replaced by ``PdfExtract.ocr_result.raw`` (or ``OCRResult.raw``).
+        Will be removed in a future minor release.
+        """
+        warnings.warn(
+            "AzureDocIntelIntegrator.last_result is deprecated and will be "
+            "removed in a future release. Use PdfExtract.ocr_result.raw or "
+            "OCRResult.raw instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(self._thread_local, "last_result", AnalyzeResult({}))
+
     def create_client(self) -> bool:
         """
         Create an Azure DocumentIntelligenceClient based on current global
@@ -110,10 +132,6 @@ class AzureDocIntelIntegrator:
             return True
         logger.error("Failed to create Azure OCR Client at endpoint='%s'", endpoint)
         return False
-
-    def reset(self):
-        """Clear last_result from previous run."""
-        self._thread_local.last_result = AnalyzeResult({})
 
     def submit(
         self,

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -3,17 +3,67 @@
 import io
 import logging
 import os
+import threading
 from dataclasses import dataclass, field
 
 from azure.ai.documentintelligence import AnalyzeDocumentLROPoller, DocumentIntelligenceClient
 from azure.ai.documentintelligence.models import AnalyzeResult, DocumentPage
 from azure.core.credentials import AzureKeyCredential
+from azure.core.pipeline.transport import RequestsTransport
 from tqdm import tqdm
 
 from . import layout
 from ._config import PyPdfToTextConfig
 
 logger = logging.getLogger(__name__)
+
+_client_cache: dict[tuple[str, str], DocumentIntelligenceClient] = {}
+"""Process-wide cache of DocumentIntelligenceClient instances keyed by
+(endpoint, key). Allows credential rotation between calls without leaking
+stale clients."""
+
+_client_cache_lock: threading.Lock = threading.Lock()
+"""Protects _client_cache against concurrent first-construction."""
+
+
+def client_for(config: PyPdfToTextConfig) -> DocumentIntelligenceClient | None:
+    """Return a DocumentIntelligenceClient for the given config's credentials.
+
+    Clients are cached by (endpoint, key) tuple, so rotating credentials
+    transparently produces a new client. The underlying urllib3 connection
+    pool size is taken from ``config.AZURE_CLIENT_POOL_MAXSIZE``.
+
+    Environment variables ``AZURE_DOCINTEL_ENDPOINT`` and
+    ``AZURE_DOCINTEL_SUBSCRIPTION_KEY`` take precedence over config fields,
+    matching the existing behavior of ``AzureDocIntelIntegrator.create_client``.
+
+    Returns:
+        A cached or newly-constructed client, or None if either endpoint or
+        key is missing.
+    """
+    endpoint = os.getenv("AZURE_DOCINTEL_ENDPOINT") or config.AZURE_DOCINTEL_ENDPOINT
+    key = os.getenv("AZURE_DOCINTEL_SUBSCRIPTION_KEY") or config.AZURE_DOCINTEL_SUBSCRIPTION_KEY
+    if not endpoint or not key:
+        return None
+    cache_key = (endpoint, key)
+    with _client_cache_lock:
+        client = _client_cache.get(cache_key)
+        if client is None:
+            transport = RequestsTransport(
+                connection_pool_maxsize=config.AZURE_CLIENT_POOL_MAXSIZE,
+            )
+            client = DocumentIntelligenceClient(
+                endpoint,
+                AzureKeyCredential(key),
+                transport=transport,
+            )
+            _client_cache[cache_key] = client
+            logger.info(
+                "Cached new Azure OCR client: endpoint='%s', pool_maxsize=%s",
+                endpoint,
+                config.AZURE_CLIENT_POOL_MAXSIZE,
+            )
+        return client
 
 
 @dataclass

--- a/pypdftotext/azure_docintel_integrator.py
+++ b/pypdftotext/azure_docintel_integrator.py
@@ -85,8 +85,20 @@ class AzureDocIntelIntegrator:
     )
 
     def reset(self):
-        """Clear last_result from previous run."""
+        """DEPRECATED. Clear the thread-local last_result.
+
+        Replaced by allowing OCRResult instances to manage their own
+        lifetime; no explicit reset is needed in the new API.
+        """
+        warnings.warn(
+            "AzureDocIntelIntegrator.reset is deprecated; OCRResult instances "
+            "manage their own lifetime. This call clears the thread-local "
+            "back-compat slot.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._thread_local.last_result = AnalyzeResult({})
+        self._thread_local.ocr_result = None
 
     @property
     def last_result(self) -> AnalyzeResult:
@@ -304,6 +316,14 @@ class AzureDocIntelIntegrator:
         results: list[str] = [
             layout.fixed_width_page(doc_page, self.config) for doc_page in ocr_pbar
         ]
+        # Populate ocr_result so deprecated wrappers (handwritten_ratio, rotation_degrees,
+        # page_at_index) can delegate to OCRResult instead of reading last_result directly.
+        self._thread_local.ocr_result = OCRResult(
+            pdf_name=pdf_name,
+            config=self.config,
+            raw=self._thread_local.last_result,
+            pages=results,
+        )
         return results
 
     def handwritten_ratio(
@@ -311,115 +331,53 @@ class AzureDocIntelIntegrator:
         page_index: int,
         handwritten_confidence_limit: float | None = None,
     ) -> float:
-        """
-        Given a page *index*, returns the ratio of handwritten to total characters on the page.
+        """DEPRECATED. Returns the handwritten ratio for the given page from
+        this thread's most-recent OCR result.
 
-        Args:
-            page_index: the 0-based index of the page to analyze
-            handwritten_confidence_limit: deprecated. use config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT
-
-        Returns:
-            float: 0.0 if the supplied page index was not OCR'd or has no text. Otherwise
-            the ratio of the sum of all handwritten spans on the page to the total page span.
+        Replaced by ``OCRResult.handwritten_ratio(page_index)`` (or
+        ``PdfExtract.ocr_result.handwritten_ratio(page_index)``).
         """
+        warnings.warn(
+            "AzureDocIntelIntegrator.handwritten_ratio is deprecated. Use "
+            "OCRResult.handwritten_ratio (e.g. via PdfExtract.ocr_result) "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if handwritten_confidence_limit is not None:
             logger.warning(
-                "Arg 'handwritten_confidence_limit' is no longer supported."
-                " Supply the desired value via `self.config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT`."
-                "\nrequested limit: %.2f (from arg)"
-                "\neffective limit: %.2f (from self.config)",
+                "handwritten_confidence_limit arg is no longer supported; "
+                "set config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT instead. "
+                "(requested=%.2f, effective=%.2f)",
                 handwritten_confidence_limit,
                 self.config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT,
             )
-
-        if _selected_page := self.page_at_index(page_index):
-            # a page should only have one span, but we'll treat as if there could be more
-            # just in case. Get the min offset from all spans as the start and the max
-            # offset + length as the page end.
-            page_start = min(span.offset for span in _selected_page.spans)
-            page_end = max(span.offset + span.length for span in _selected_page.spans)
-            # Now we'll account for selection marks since prebuilt-layout output replaces
-            # checkboxes and the like with ':selected:' or ':unselected:' and includes this
-            # unrendered text in span offsets (like an asshole).
-            page_length_reduction = sum(
-                sel.span.length for sel in _selected_page.selection_marks or []
-            )
-            # finally, we'll ignore newline chars that occur in the page span
-            page_length_reduction += self._thread_local.last_result.content[
-                page_start:page_end
-            ].count("\n")
-            page_length = page_end - page_start - page_length_reduction
-            if page_length <= 0:
-                # whoops! something's wrong. We should probably throw an exception here, but
-                # we'll fail open for now as it fits our use case.
-                logger.warning(
-                    "Error calculating handwritten ratio for page at index %s:"
-                    " page span length reduction (%s) + start (%s) >= end (%s)",
-                    page_index,
-                    page_length_reduction,
-                    page_start,
-                    page_end,
-                )
-                return 0.0
-            # lets get the sum of span lengths for all is_handwritten styles with confidences
-            # >= our threshold that also occur between page_start and page_end!
-            handwritten_length = sum(
-                (
-                    (span.offset + min(span.length, page_end)) - span.offset
-                    for style in (self._thread_local.last_result.styles or [])
-                    if style.is_handwritten
-                    and style.confidence >= self.config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT
-                    for span in style.spans
-                    if page_start <= span.offset < page_end
-                ),
-                start=0,
-            )
-            # Guess we'll cap our value at 1.0. We should probably throw and exception here
-            # also, but again we'll fail open for now as it suits our use case.
-            ratio = handwritten_length / page_length
-            if ratio > 1.0:
-                logger.warning("Handwritten ratio of page index at %s capped at 1.0", page_index)
-                return 1.0
-            return ratio
-        # page was not OCR'd return 0.0 default.
-        return 0.0
+        result = getattr(self._thread_local, "ocr_result", None)
+        return result.handwritten_ratio(page_index) if result is not None else 0.0
 
     def rotation_degrees(self, page_index: int) -> float:
-        """
-        Given a page *index*, returns the degrees of rotation of the page reported by Azure.
-
-        Args:
-            page_index: the 0-based index of the page to analyze
-
-        Returns:
-            float: 0.0 if the supplied page index was not OCR'd. Otherwise
-                the page's reported rotation in degrees.
-        """
-        if _selected_page := self.page_at_index(page_index):
-            angle = _selected_page.angle or 0.0
-            if abs(angle) > self.config.MIN_OCR_ROTATION_DEGREES:
-                logger.debug("Page at index %s is rotated %.2f degrees", page_index, angle)
-                return angle
-        return 0.0
+        """DEPRECATED. See OCRResult.rotation_degrees."""
+        warnings.warn(
+            "AzureDocIntelIntegrator.rotation_degrees is deprecated. Use "
+            "OCRResult.rotation_degrees (e.g. via PdfExtract.ocr_result) "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        result = getattr(self._thread_local, "ocr_result", None)
+        return result.rotation_degrees(page_index) if result is not None else 0.0
 
     def page_at_index(self, page_index: int) -> DocumentPage | None:
-        """
-        Returns the DocumentPage instance having the given page *index* or None.
-
-        Args:
-            page_index: the 0-based index of the page to analyze
-
-        Returns:
-            DocumentPage | None: None if the supplied page index was not OCR'd.
-        """
-        if any(
-            # find the page at the supplied index and report its angle. otherwise return 0.0.
-            (_selected_page := page).page_number == page_index + 1
-            for page in self._thread_local.last_result.pages
-        ):
-            return _selected_page
-        # page was not OCR'd. Return None.
-        return None
+        """DEPRECATED. See OCRResult.page_at_index."""
+        warnings.warn(
+            "AzureDocIntelIntegrator.page_at_index is deprecated. Use "
+            "OCRResult.page_at_index (e.g. via PdfExtract.ocr_result) "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        result = getattr(self._thread_local, "ocr_result", None)
+        return result.page_at_index(page_index) if result is not None else None
 
 
 AZURE_READ = AzureDocIntelIntegrator()

--- a/pypdftotext/batch.py
+++ b/pypdftotext/batch.py
@@ -8,13 +8,13 @@ from collections.abc import Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from azure.core.exceptions import AzureError
 from pypdf import PdfReader
 from tqdm import tqdm
 
 from ._config import PyPdfToTextConfig, PyPdfToTextConfigOverrides
-from .azure_docintel_integrator import AzureDocIntelIntegrator
+from .azure_docintel_integrator import AZURE_READ, await_all
 from .header_footer_detection import assign_headers_and_footers
+from .ocr_result import OCRResult
 from .pdf_extract import PdfExtract
 
 logger = logging.getLogger(__name__)
@@ -178,9 +178,8 @@ class PdfExtractBatch:
         return self.pdf_extracts
 
     def _perform_batch_ocr(self) -> dict[str, PdfExtract]:
-        """Perform OCR for all collected pages in parallel."""
-
-        ocr_pdfs = {  # get pdfs that need OCR
+        """Submit all OCR-eligible PDFs, await collectively, apply results."""
+        ocr_pdfs = {
             pdf_name: extract
             for pdf_name, extract in self.pdf_extracts.items()
             if (
@@ -196,55 +195,51 @@ class PdfExtractBatch:
             )
             return self.pdf_extracts
         total_pages = sum(len(ext.ocr_page_idxs) for ext in ocr_pdfs.values())
-        logger.info("Submitting %s pages across %s PDFs for batch OCR", total_pages, len(ocr_pdfs))
-
-        # Process PDFs in parallel using ThreadPoolExecutor
-        with ThreadPoolExecutor(
-            max_workers=min(len(ocr_pdfs), self.config.MAX_WORKERS)
-        ) as executor:
-            futures: list[Future[tuple[str, PdfExtract]]] = []
-            for pdf_name, pdf_ext in ocr_pdfs.items():
-                futures.append(executor.submit(self._ocr_single_pdf, (pdf_name, pdf_ext)))
-
-            # Process results as they complete
-            pbar = tqdm(
-                as_completed(futures),
-                total=len(futures),
-                desc="Processing OCR results",
-                disable=self.config.DISABLE_PROGRESS_BAR,
-                position=self.config.PROGRESS_BAR_POSITION,
-                leave=None,
+        logger.info(
+            "Submitting %s pages across %s PDFs for batch OCR",
+            total_pages,
+            len(ocr_pdfs),
+        )
+        # Phase 1: submit all
+        pollers = {}
+        for pdf_name, extract in ocr_pdfs.items():
+            poller = AZURE_READ.submit(
+                extract.body,
+                extract.ocr_page_idxs,
+                pdf_name=pdf_name,
+                config=self.config,
             )
-
-            for i, future in enumerate(pbar):
-                pdf_name, _ = future.result()
-                logger.debug("OCR complete for %s (%s/%s)", pdf_name, i, len(ocr_pdfs))
+            if poller is not None:
+                pollers[pdf_name] = poller
+            else:
+                # No client available; record failure inline.
+                extract._apply_ocr_result(
+                    OCRResult(
+                        pdf_name=pdf_name,
+                        config=self.config,
+                        raw=None,
+                        pages=[],
+                        error="OCR failed: no client available "
+                        "(check AZURE_DOCINTEL_ENDPOINT and AZURE_DOCINTEL_SUBSCRIPTION_KEY)",
+                    )
+                )
+        # Phase 2: collective wait
+        results = await_all(
+            pollers,
+            AZURE_READ,
+            timeout=self.config.AZURE_DOCINTEL_TIMEOUT,
+            config=self.config,
+        )
+        # Phase 3: apply
+        for pdf_name, extract in ocr_pdfs.items():
+            if pdf_name in results:
+                try:
+                    extract._apply_ocr_result(results[pdf_name])
+                except Exception as e:  # noqa: BLE001  # batch survives per-PDF apply failures
+                    logger.error(
+                        "PdfExtractBatch apply error for %s: %s",
+                        pdf_name,
+                        e,
+                        exc_info=logger.getEffectiveLevel() == logging.DEBUG,
+                    )
         return self.pdf_extracts
-
-    def _ocr_single_pdf(self, pdf_info: tuple[str, PdfExtract]) -> tuple[str, PdfExtract]:
-        """OCR a single PDF's pages."""
-        pdf_name, pdf_extract = pdf_info
-        try:
-            logger.debug("Begin OCR for %s", pdf_name)
-            azure = AzureDocIntelIntegrator(self.config)
-            if self.config.AZURE_DOCINTEL_AUTO_CLIENT and azure.client is None:
-                azure.create_client()
-
-            # Run OCR for this extract.
-            pdf_extract.ocr(azure)
-        except AzureError as azure_error:
-            logger.error(
-                "PdfExtractBatch Azure Error for %s: %s",
-                pdf_name,
-                azure_error,
-                exc_info=logger.getEffectiveLevel() == logging.DEBUG,
-            )
-        except Exception as e:  # noqa: BLE001  # batch must survive per-PDF OCR failures; AzureError caught above
-            logger.error(
-                "PdfExtractBatch Error for %s: %s",
-                pdf_name,
-                e,
-                exc_info=logger.getEffectiveLevel() == logging.DEBUG,
-            )
-
-        return pdf_name, pdf_extract

--- a/pypdftotext/extracted_page.py
+++ b/pypdftotext/extracted_page.py
@@ -35,6 +35,8 @@ class ExtractedPage:
             PdfExtract().assign_document_indices() will dynamically set this value.
         header: Text detected as a header on this page.
         footer: Text detected as a footer on this page.
+        ocr_error: Failure reason set when OCR was attempted and failed. None
+            when OCR succeeded or was never attempted.
     """
 
     page_obj: PageObject
@@ -45,6 +47,9 @@ class ExtractedPage:
     document_idx: int = 0
     header: str = ""
     footer: str = ""
+    ocr_error: str | None = None
+    """Failure reason set when OCR was attempted and did not complete successfully.
+    None if OCR succeeded OR if OCR was never attempted for this page."""
 
     @cached_property
     def fingerprint(self):

--- a/pypdftotext/extracted_page.py
+++ b/pypdftotext/extracted_page.py
@@ -22,20 +22,20 @@ class ExtractedPage:
 
     Attributes:
         page_obj: The pypdf PageObject instance for this page.
-        handwritten_ratio: Ratio of handwritten to total characters (0.0 to 1.0).
+        handwritten_ratio: Ratio of handwritten to total characters (0.0 to 1.0). \
             Always 0.0 for embedded text pages.
         text: The extracted text content from the page. Excludes header and footer.
-        source: Indicates whether text was extracted from embedded PDF content
+        source: Indicates whether text was extracted from embedded PDF content \
             ("embedded") or via OCR ("OCR").
         azure_page: The Azure DocumentPage instance if this page was OCR'd,
             None for embedded text pages.
-        document_idx: An integer representing the ancestry of the page. Pages
-            with a common document_idx likely originated from the same source.
-            Used for header/footer detection. Default is 0. Calling the
+        document_idx: An integer representing the ancestry of the page. Pages \
+            with a common document_idx likely originated from the same source. \
+            Used for header/footer detection. Default is 0. Calling the \
             PdfExtract().assign_document_indices() will dynamically set this value.
         header: Text detected as a header on this page.
         footer: Text detected as a footer on this page.
-        ocr_error: Failure reason set when OCR was attempted and failed. None
+        ocr_error: Failure reason set when OCR was attempted and failed. None \
             when OCR succeeded or was never attempted.
     """
 
@@ -48,8 +48,6 @@ class ExtractedPage:
     header: str = ""
     footer: str = ""
     ocr_error: str | None = None
-    """Failure reason set when OCR was attempted and did not complete successfully.
-    None if OCR succeeded OR if OCR was never attempted for this page."""
 
     @cached_property
     def fingerprint(self):

--- a/pypdftotext/ocr_result.py
+++ b/pypdftotext/ocr_result.py
@@ -29,8 +29,9 @@ class OCRResult:
             this snapshot rather than from any current global state.
         raw: The underlying AnalyzeResult returned by the Azure SDK; None when
             the operation failed before producing a result.
-        pages: One rendered fixed-width text string per page index submitted,
-            in submission order. Empty when the OCR call failed.
+         pages: One rendered fixed-width text string per page in the order
+             provided by the Azure SDK result (typically increasing
+             ``page_number``). Empty when the OCR call failed.
         error: Human-readable failure description prefixed with ``OCR
             <verb>:`` (e.g. ``"OCR timeout: ..."``). None when the call
             succeeded.

--- a/pypdftotext/ocr_result.py
+++ b/pypdftotext/ocr_result.py
@@ -1,0 +1,137 @@
+"""Per-OCR-call value type. Replaces session-scoped AzureDocIntelIntegrator.last_result."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from azure.ai.documentintelligence.models import AnalyzeResult, DocumentPage
+
+from ._config import PyPdfToTextConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OCRResult:
+    """Result of a single OCR call against Azure Document Intelligence.
+
+    Carries the rendered fixed-width page strings, the underlying SDK
+    ``AnalyzeResult`` (or ``None`` on hard failure), and an optional
+    human-readable error string. Replaces the session-scoped
+    ``AzureDocIntelIntegrator.last_result`` attribute, so two concurrent OCR
+    calls cannot alias each other's per-page metadata.
+
+    Attributes:
+        pdf_name: Identifier for the source PDF; useful for log correlation.
+        config: Snapshot of the PyPdfToTextConfig in effect when the OCR call
+            was submitted. Methods like handwritten_ratio read thresholds from
+            this snapshot rather than from any current global state.
+        raw: The underlying AnalyzeResult returned by the Azure SDK; None when
+            the operation failed before producing a result.
+        pages: One rendered fixed-width text string per page index submitted,
+            in submission order. Empty when the OCR call failed.
+        error: Human-readable failure description prefixed with ``OCR
+            <verb>:`` (e.g. ``"OCR timeout: ..."``). None when the call
+            succeeded.
+    """
+
+    pdf_name: str
+    config: PyPdfToTextConfig
+    raw: AnalyzeResult | None
+    pages: list[str] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """True iff no error was recorded and the SDK returned a result with at
+        least one page.
+
+        Example:
+            >>> from pypdftotext import PyPdfToTextConfig
+            >>> from pypdftotext.ocr_result import OCRResult
+            >>> OCRResult(pdf_name="x", config=PyPdfToTextConfig(), raw=None,
+            ...           pages=[], error="OCR timeout").succeeded
+            False
+            >>> OCRResult(pdf_name="x", config=PyPdfToTextConfig(), raw=None,
+            ...           pages=[]).succeeded
+            False
+        """
+        return self.error is None and self.raw is not None and bool(self.raw.pages)
+
+    def page_at_index(self, page_index: int) -> DocumentPage | None:
+        """Return the DocumentPage at the given 0-based index, or None.
+
+        Returns None when the OCR call failed OR when the index is out of
+        range relative to ``self.raw.pages``.
+
+        Example:
+            >>> from pypdftotext import PyPdfToTextConfig
+            >>> from pypdftotext.ocr_result import OCRResult
+            >>> OCRResult(pdf_name="x", config=PyPdfToTextConfig(), raw=None,
+            ...           pages=[]).page_at_index(0) is None
+            True
+        """
+        if self.raw is None or not self.raw.pages:
+            return None
+        for page in self.raw.pages:
+            if page.page_number == page_index + 1:
+                return page
+        return None
+
+    def rotation_degrees(self, page_index: int) -> float:
+        """Return Azure's reported rotation in degrees for the given page.
+
+        Returns 0.0 when the OCR call failed, the page is missing from the
+        result, or the reported angle is below
+        ``self.config.MIN_OCR_ROTATION_DEGREES``.
+        """
+        page = self.page_at_index(page_index)
+        if page is None:
+            return 0.0
+        angle = page.angle or 0.0
+        if abs(angle) > self.config.MIN_OCR_ROTATION_DEGREES:
+            return angle
+        return 0.0
+
+    def handwritten_ratio(self, page_index: int) -> float:
+        """Return the ratio of handwritten characters to total characters on
+        the given page (0.0 to 1.0).
+
+        Uses ``self.config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT`` as the minimum
+        confidence threshold for counting a span as handwritten. Returns 0.0
+        when the OCR call failed or the page has no text.
+        """
+        if self.raw is None:
+            return 0.0
+        page = self.page_at_index(page_index)
+        if page is None or not page.spans:
+            return 0.0
+        page_start = min(span.offset for span in page.spans)
+        page_end = max(span.offset + span.length for span in page.spans)
+        # Selection marks like :selected: and :unselected: are encoded in
+        # span offsets but not rendered; subtract their lengths.
+        length_reduction = sum(sel.span.length for sel in (page.selection_marks or []))
+        # And subtract embedded newlines.
+        length_reduction += self.raw.content[page_start:page_end].count("\n")
+        page_length = page_end - page_start - length_reduction
+        if page_length <= 0:
+            logger.warning(
+                "Cannot compute handwritten ratio for page index %s: "
+                "length reduction (%s) >= span (%s, %s)",
+                page_index,
+                length_reduction,
+                page_start,
+                page_end,
+            )
+            return 0.0
+        threshold = self.config.OCR_HANDWRITTEN_CONFIDENCE_LIMIT
+        handwritten_length = sum(
+            min(span.length, page_end - span.offset)
+            for style in (self.raw.styles or [])
+            if style.is_handwritten and style.confidence >= threshold
+            for span in style.spans
+            if page_start <= span.offset < page_end
+        )
+        ratio = handwritten_length / page_length
+        return min(ratio, 1.0)

--- a/pypdftotext/ocr_result.py
+++ b/pypdftotext/ocr_result.py
@@ -102,7 +102,7 @@ class OCRResult:
         confidence threshold for counting a span as handwritten. Returns 0.0
         when the OCR call failed or the page has no text.
         """
-        if self.raw is None:
+        if self.raw is None or not self.raw.content:
             return 0.0
         page = self.page_at_index(page_index)
         if page is None or not page.spans:

--- a/pypdftotext/pdf_extract.py
+++ b/pypdftotext/pdf_extract.py
@@ -352,10 +352,12 @@ class PdfExtract:
                     json.dumps(ocr_pages, indent=2, default=str), "utf-8"
                 )
                 (self.debug_path / "azure.json").write_text(
-                    json.dumps(azure.last_result.as_dict(), indent=2), "utf-8"
+                    json.dumps(azure._thread_local.last_result.as_dict(), indent=2),
+                    "utf-8",
                 )
                 (self.debug_path / "azure_content.txt").write_text(
-                    azure.last_result.content, "utf-8"
+                    azure._thread_local.last_result.content or "",
+                    "utf-8",
                 )
             for ocr_idx, og_pg_idx in enumerate(self.ocr_page_idxs):
                 ext_pg = self.extracted_pages[og_pg_idx]

--- a/pypdftotext/pdf_extract.py
+++ b/pypdftotext/pdf_extract.py
@@ -17,9 +17,10 @@ from pypdf.generic import DictionaryObject, NullObject
 from tqdm import tqdm
 
 from ._config import PyPdfToTextConfig, PyPdfToTextConfigOverrides
-from .azure_docintel_integrator import AzureDocIntelIntegrator
+from .azure_docintel_integrator import AZURE_READ, AzureDocIntelIntegrator
 from .extracted_page import ExtractedPage
 from .header_footer_detection import assign_headers_and_footers
+from .ocr_result import OCRResult
 
 try:
     import boto3
@@ -105,6 +106,7 @@ class PdfExtract:
         self._azure: AzureDocIntelIntegrator | None = kwargs.get("azure")
         self._batch_mode: bool = kwargs.get("_batch_mode", False)
         self.ocr_page_idxs: list[int] = []
+        self.ocr_result: OCRResult | None = None  # set by ocr() if OCR runs
         self._reader: PdfReader | None = None
         self._writer: PdfWriter | None = None
         self._pbar: tqdm | None = None
@@ -299,9 +301,10 @@ class PdfExtract:
             for txt, pg in zip(pre_ocr, self.reader.pages)
         ]
         self.ocr_page_idxs = [itm for itm in pre_ocr if isinstance(itm, int)]
-        if self._azure:
-            self._azure.config = self.config
-        azure = AzureDocIntelIntegrator(self.config) if self._azure is None else self._azure
+        if self._azure is not None:
+            azure = self._azure
+        else:
+            azure = AZURE_READ
 
         # Parallel Azure OCR API calls will be made later if in batch mode.
         if not self._batch_mode:
@@ -323,75 +326,106 @@ class PdfExtract:
             assign_headers_and_footers(self.extracted_pages, self.config)
         return self._extracted_pages
 
-    def ocr(self, azure: AzureDocIntelIntegrator):
+    def ocr(self, azure: AzureDocIntelIntegrator | None = None):
+        """Run OCR on the pages identified during _extract_pages, applying
+        results to self.extracted_pages.
+
+        Args:
+            azure: integrator to use. Defaults to the canonical AZURE_READ
+                singleton; pass an explicit instance if you need credential
+                isolation across PdfExtract instances.
         """
-        Run OCR on identified indices if the fraction of pages having fewer
-        than `self.config.MIN_LINES_OCR_TRIGGER` lines is greater than or equal to
-        `self.config.TRIGGER_OCR_PAGE_RATIO`. Updates the proper self.extracted_pages
-        entries with OCR'd text and handwritten ratios if OCR is triggered.
-        """
-        rotated_pages = False  # track whether we rotated any pages and regenerate self.body if so.
-        # do not OCR unless the number of pages requiring OCR / total pages exceeds a target ratio.
-        # Skip OCR if in batch mode (will be handled by batch processor)
+        if azure is None:
+            azure = AZURE_READ
         if (
             len(self.ocr_page_idxs) / len(self.extracted_pages)
-            >= self.config.TRIGGER_OCR_PAGE_RATIO
+            < self.config.TRIGGER_OCR_PAGE_RATIO
         ):
-            # if not in batch mode, replacements are handled globally in _extract_pages.
-            if not self._batch_mode:
-                replacements = []
-            else:
-                replacements = [
-                    (old_bytes.decode(), new_bytes.decode())
-                    for old_bytes, new_bytes in (self.config.REPLACE_BYTE_CODES or {}).items()
-                ]
+            return
+        poller = azure.submit(
+            self.body,
+            self.ocr_page_idxs,
+            pdf_name=self.pdf_name,
+            config=self.config,
+        )
+        if poller is None:
+            logger.error(
+                "[%s] OCR submit failed: no client available",
+                self.pdf_name,
+            )
+            return
+        result = azure.await_one(poller, pdf_name=self.pdf_name, config=self.config)
+        self._apply_ocr_result(result)
 
-            ocr_pages = azure.ocr_pages(self.body, self.ocr_page_idxs, pdf_name=self.pdf_name)
-            if self.debug_path:
-                (self.debug_path / "ocr_pages.json").write_text(
-                    json.dumps(ocr_pages, indent=2, default=str), "utf-8"
+    def _apply_ocr_result(self, result: OCRResult) -> None:
+        """Apply an OCRResult to self.extracted_pages.
+
+        On success: each ocr_page_idx page gets its rendered text,
+        source="OCR", handwritten_ratio, and azure_page populated; rotations
+        are applied where Azure reports non-zero angles.
+
+        On failure: every ocr_page_idx page gets ocr_error set; text stays
+        empty, source stays "embedded", azure_page stays None.
+
+        In both cases self.ocr_result is stashed for downstream introspection.
+        """
+        self.ocr_result = result
+        rotated_pages = False
+        if not result.succeeded:
+            logger.error("[%s] OCR did not complete: %s", self.pdf_name, result.error)
+            for og_pg_idx in self.ocr_page_idxs:
+                self.extracted_pages[og_pg_idx].ocr_error = result.error
+            return
+        replacements = (
+            [
+                (old_bytes.decode(), new_bytes.decode())
+                for old_bytes, new_bytes in (self.config.REPLACE_BYTE_CODES or {}).items()
+            ]
+            if self._batch_mode
+            else []
+        )
+        for ocr_idx, og_pg_idx in enumerate(self.ocr_page_idxs):
+            ext_pg = self.extracted_pages[og_pg_idx]
+            txt = result.pages[ocr_idx]
+            if len(txt) > self.config.MAX_CHARS_PER_PDF_PAGE:
+                logger.warning(
+                    "[%s] Clearing corrupt OCR text pg_idx=%s; len(txt)=%s > %s char limit."
+                    " Does page contain multiple text orientations?",
+                    self.pdf_name,
+                    og_pg_idx,
+                    len(txt),
+                    self.config.MAX_CHARS_PER_PDF_PAGE,
                 )
-                (self.debug_path / "azure.json").write_text(
-                    json.dumps(azure._thread_local.last_result.as_dict(), indent=2),
-                    "utf-8",
-                )
-                (self.debug_path / "azure_content.txt").write_text(
-                    azure._thread_local.last_result.content or "",
-                    "utf-8",
-                )
-            for ocr_idx, og_pg_idx in enumerate(self.ocr_page_idxs):
-                ext_pg = self.extracted_pages[og_pg_idx]
-                txt = ocr_pages[ocr_idx]
-                if len(txt) > self.config.MAX_CHARS_PER_PDF_PAGE:
-                    logger.warning(
-                        "[%s] Clearing corrupt OCR text pg_idx=%s; len(txt)=%s > %s char limit."
-                        " Does page contain multiple text orientations?",
-                        self.pdf_name,
-                        og_pg_idx,
-                        len(txt),
-                        self.config.MAX_CHARS_PER_PDF_PAGE,
-                    )
-                    txt = ""
-                elif rotation := azure.rotation_degrees(og_pg_idx):
-                    # rotations can only be applied to pages in 90 degree increments.
-                    # do not report rotated content if applied rotation is 0.
-                    if applied_rotation := -90 * int(round(rotation / 90.0)):
-                        rotated_pages = True
-                        ext_pg.page_obj.rotation += applied_rotation
-
-                # perform byte code substitutions per 'replace_byte_codes' arg if in batch mode
-                if replacements and txt:
-                    for old_, new_ in replacements:
-                        txt = txt.replace(old_, new_)
-
-                ext_pg.text = txt
-                ext_pg.source = "OCR"
-                ext_pg.handwritten_ratio = azure.handwritten_ratio(og_pg_idx)
-                ext_pg.azure_page = azure.page_at_index(og_pg_idx)
-
+                txt = ""
+            elif rotation := result.rotation_degrees(og_pg_idx):
+                if applied_rotation := -90 * int(round(rotation / 90.0)):
+                    rotated_pages = True
+                    ext_pg.page_obj.rotation += applied_rotation
+            if replacements and txt:
+                for old_, new_ in replacements:
+                    txt = txt.replace(old_, new_)
+            ext_pg.text = txt
+            ext_pg.source = "OCR"
+            ext_pg.handwritten_ratio = result.handwritten_ratio(og_pg_idx)
+            ext_pg.azure_page = result.page_at_index(og_pg_idx)
+            ext_pg.ocr_error = None
         if rotated_pages:
             logger.debug("[%s] Regenerating body with corrected page orientations.", self.pdf_name)
             self._regenerate_body()
+        if self.debug_path and self.ocr_result is not None:
+            (self.debug_path / "ocr_pages.json").write_text(
+                json.dumps(self.ocr_result.pages, indent=2, default=str),
+                "utf-8",
+            )
+            if self.ocr_result.raw is not None:
+                (self.debug_path / "azure.json").write_text(
+                    json.dumps(self.ocr_result.raw.as_dict(), indent=2),
+                    "utf-8",
+                )
+                (self.debug_path / "azure_content.txt").write_text(
+                    self.ocr_result.raw.content or "",
+                    "utf-8",
+                )
 
     @overload
     def remove_pages(self, remove: Callable[[ExtractedPage], bool], raise_on_empty: bool = True):

--- a/tests/test_await_all.py
+++ b/tests/test_await_all.py
@@ -1,0 +1,105 @@
+"""Tests for the module-level await_all collective wait helper."""
+
+import threading
+import unittest
+from unittest.mock import MagicMock
+
+from pypdftotext import PyPdfToTextConfig
+from pypdftotext.azure_docintel_integrator import (
+    AzureDocIntelIntegrator,
+    await_all,
+)
+
+
+def _fake_poller(immediate_result=None, raises=None):
+    """Build a mocked poller that simulates SDK semantics.
+
+    If immediate_result is set, the poller is treated as already "done":
+        - add_done_callback(fn) calls fn(poller) immediately and
+          synchronously, mimicking the SDK firing callbacks when the
+          background poll detects completion before the caller registers.
+        - result(timeout) returns the stored result.
+
+    If raises is set, the poller behaves like the SDK raising on result()
+    (e.g., HttpResponseError). Callbacks are still fired immediately.
+    """
+    poller = MagicMock()
+    poller._polling_method = MagicMock()
+    poller._polling_method.cancel_event = threading.Event()
+
+    def _add_done_callback(fn):
+        # SDK fires this synchronously if the LRO is already complete.
+        fn(poller)
+
+    poller.add_done_callback.side_effect = _add_done_callback
+
+    if raises is not None:
+        poller.result.side_effect = raises
+    else:
+        poller.result.return_value = immediate_result
+    return poller
+
+
+def _make_analyze_result(label):
+    from azure.ai.documentintelligence.models import AnalyzeResult
+    return AnalyzeResult({
+        "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+        "stringIndexType": "textElements", "content": label,
+        "pages": [{"pageNumber": 1, "angle": 0.0, "width": 8.5, "height": 11.0,
+                   "unit": "inch", "spans": [{"offset": 0, "length": len(label)}],
+                   "words": [], "lines": [], "selectionMarks": []}],
+        "styles": [],
+    })
+
+
+class TestAwaitAll(unittest.TestCase):
+    def setUp(self):
+        self.cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+        self.integrator = AzureDocIntelIntegrator(self.cfg)
+
+    def test_await_all_collects_all_results(self):
+        """N=0, N=1, N=3 all return well-formed dicts."""
+        for size in (0, 1, 3):
+            with self.subTest(size=size):
+                pollers = {
+                    f"pdf{i}": _fake_poller(immediate_result=_make_analyze_result(f"pdf{i}"))
+                    for i in range(size)
+                }
+                results = await_all(
+                    pollers, self.integrator, timeout=5.0, config=self.cfg,
+                )
+                self.assertEqual(len(results), size)
+                for name in pollers:
+                    self.assertTrue(results[name].succeeded)
+
+    def test_await_all_synthesizes_budget_exceeded_on_timeout(self):
+        """Pollers that don't complete by the budget get synthesized error
+        results; a poller that completes during the grace window wins."""
+        # Poller A completes immediately.
+        poller_a = _fake_poller(immediate_result=_make_analyze_result("alpha"))
+
+        # Poller B never fires its callback — simulates "still polling".
+        poller_b = MagicMock()
+        poller_b._polling_method = MagicMock()
+        poller_b._polling_method.cancel_event = threading.Event()
+        # Don't fire on add_done_callback (just register it).
+        poller_b.add_done_callback.side_effect = lambda fn: None
+        # If anything ever does call result, return None (the silent-timeout case).
+        poller_b.result.return_value = None
+
+        pollers = {"alpha": poller_a, "bravo": poller_b}
+        # Short budget so timeout fires fast.
+        results = await_all(pollers, self.integrator, timeout=0.5, config=self.cfg)
+
+        self.assertTrue(results["alpha"].succeeded)
+        self.assertFalse(results["bravo"].succeeded)
+        self.assertTrue(results["bravo"].error.startswith("OCR batch budget exceeded"))
+        # Cancellation was attempted on the still-pending poller.
+        self.assertTrue(poller_b._polling_method.cancel_event.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_await_all.py
+++ b/tests/test_await_all.py
@@ -101,5 +101,67 @@ class TestAwaitAll(unittest.TestCase):
         self.assertTrue(poller_b._polling_method.cancel_event.is_set())
 
 
+class TestAwaitAllThreadSafety(unittest.TestCase):
+    """Regression: callbacks must NOT call poller.result() because they fire
+    on the SDK's daemon polling thread, which would self-join."""
+
+    def setUp(self):
+        self.cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+        self.integrator = AzureDocIntelIntegrator(self.cfg)
+
+    def test_callback_does_not_call_result(self):
+        """If await_all's callback called poller.result() on the daemon
+        thread, real SDK pollers would raise RuntimeError. Verify the
+        callback only signals completion — poller.result() is called from
+        the coordinating thread later."""
+        from azure.ai.documentintelligence.models import AnalyzeResult
+
+        # Construct a poller mock that tracks which thread calls result().
+        result_thread = {}
+        raw = AnalyzeResult({
+            "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+            "stringIndexType": "textElements", "content": "x",
+            "pages": [{"pageNumber": 1, "angle": 0.0, "width": 8.5,
+                       "height": 11.0, "unit": "inch",
+                       "spans": [{"offset": 0, "length": 1}],
+                       "words": [], "lines": [], "selectionMarks": []}],
+            "styles": [],
+        })
+
+        poller = MagicMock()
+        poller._polling_method = MagicMock()
+        poller._polling_method.cancel_event = threading.Event()
+
+        # Simulate the SDK firing the callback on a DIFFERENT thread (its
+        # own daemon thread), not the coordinator thread.
+        def fire_on_daemon_thread(fn):
+            t = threading.Thread(
+                target=fn, args=(poller._polling_method,), daemon=True,
+            )
+            t.start()
+            t.join()  # ensure callback completes before add_done_callback returns
+
+        poller.add_done_callback.side_effect = fire_on_daemon_thread
+
+        def record_thread_and_return(*args, **kwargs):
+            result_thread["name"] = threading.current_thread().name
+            return raw
+
+        poller.result.side_effect = record_thread_and_return
+
+        coordinator_thread_name = threading.current_thread().name
+        results = await_all({"pdf1": poller}, self.integrator, timeout=2.0, config=self.cfg)
+
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results["pdf1"].succeeded)
+        # poller.result() MUST have been called from the coordinator thread
+        # (not the daemon thread that fired the callback). If the callback
+        # called result(), result_thread['name'] would be the daemon's name.
+        self.assertEqual(result_thread.get("name"), coordinator_thread_name)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_azure_docintel_integrator.py
+++ b/tests/test_azure_docintel_integrator.py
@@ -262,6 +262,97 @@ class TestDeprecatedSurface(unittest.TestCase):
         self.assertIsInstance(value, AnalyzeResult)
         self.assertIsNone(value.pages)  # AnalyzeResult({}).pages is None.
 
+    def test_handwritten_ratio_back_compat(self):
+        """Deprecated wrapper returns the same value as OCRResult.handwritten_ratio."""
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result, _ = self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            integrator_value = integrator.handwritten_ratio(0)
+        # Warning emitted.
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(caught[0].category, DeprecationWarning)
+        # Value matches OCRResult.
+        self.assertEqual(integrator_value, result.handwritten_ratio(0))
+
+    def test_rotation_degrees_back_compat(self):
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result, _ = self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self.assertEqual(integrator.rotation_degrees(0), result.rotation_degrees(0))
+        self.assertEqual(caught[0].category, DeprecationWarning)
+
+    def test_page_at_index_back_compat(self):
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result, _ = self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self.assertIs(integrator.page_at_index(0), result.page_at_index(0))
+        self.assertEqual(caught[0].category, DeprecationWarning)
+
+    def test_reset_clears_thread_local_with_warning(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            integrator.reset()
+        self.assertEqual(caught[0].category, DeprecationWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            self.assertIsNone(integrator.last_result.pages)  # back to empty sentinel
+
+
+class TestThreadLocalIsolation(unittest.TestCase):
+    def setUp(self):
+        with _client_cache_lock:
+            _client_cache.clear()
+
+    def test_thread_local_isolation_across_threads(self):
+        """REGRESSION (P4): two threads sharing one integrator each see their
+        own most-recent OCR result, not each other's."""
+        from azure.ai.documentintelligence.models import AnalyzeResult
+
+        def make_raw(label):
+            return AnalyzeResult({
+                "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+                "stringIndexType": "textElements", "content": label,
+                "pages": [{"pageNumber": 1, "angle": 0.0, "width": 8.5,
+                           "height": 11.0, "unit": "inch",
+                           "spans": [{"offset": 0, "length": len(label)}],
+                           "words": [], "lines": [], "selectionMarks": []}],
+                "styles": [],
+            })
+
+        cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+        integrator = AzureDocIntelIntegrator(cfg)
+        results = {}
+
+        def worker(label):
+            poller = MagicMock()
+            poller.result.return_value = make_raw(label)
+            integrator.await_one(poller, pdf_name=label)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                results[label] = integrator.last_result.content
+
+        threads = [
+            threading.Thread(target=worker, args=("alpha",)),
+            threading.Thread(target=worker, args=("bravo",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Each thread saw its own label, not the other's.
+        self.assertEqual(results["alpha"], "alpha")
+        self.assertEqual(results["bravo"], "bravo")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_azure_docintel_integrator.py
+++ b/tests/test_azure_docintel_integrator.py
@@ -1,0 +1,81 @@
+"""Tests for AzureDocIntelIntegrator and its module-level helpers."""
+
+import os
+import threading
+import unittest
+import warnings
+from unittest.mock import MagicMock, patch
+
+from pypdftotext import PyPdfToTextConfig
+from pypdftotext.azure_docintel_integrator import (
+    AzureDocIntelIntegrator,
+    AZURE_READ,
+    client_for,
+    _client_cache,
+    _client_cache_lock,
+)
+
+
+class TestClientFor(unittest.TestCase):
+    def setUp(self):
+        # Reset the cache between tests so they're hermetic.
+        with _client_cache_lock:
+            _client_cache.clear()
+
+    def _config_with_creds(self, endpoint, key, pool_maxsize=20):
+        return PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": endpoint,
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": key,
+            "AZURE_CLIENT_POOL_MAXSIZE": pool_maxsize,
+        })
+
+    def test_client_for(self):
+        """Parametrized: caching, missing creds, pool size kwarg."""
+        # Clear environment AZURE_* vars so config values take precedence.
+        with patch.dict(os.environ, {}, clear=False):
+            for var in ("AZURE_DOCINTEL_ENDPOINT", "AZURE_DOCINTEL_SUBSCRIPTION_KEY"):
+                os.environ.pop(var, None)
+
+            # 1. Missing creds → None.
+            self.assertIsNone(client_for(self._config_with_creds("", "")))
+            self.assertIsNone(client_for(self._config_with_creds("https://x.example", "")))
+            self.assertIsNone(client_for(self._config_with_creds("", "key123")))
+
+            # 2. Same (endpoint, key) → same client object.
+            cfg_a1 = self._config_with_creds("https://a.example", "key-a")
+            cfg_a2 = self._config_with_creds("https://a.example", "key-a")
+            client_a1 = client_for(cfg_a1)
+            client_a2 = client_for(cfg_a2)
+            self.assertIsNotNone(client_a1)
+            self.assertIs(client_a1, client_a2)
+
+            # 3. Different key → different client.
+            cfg_b = self._config_with_creds("https://a.example", "key-b")
+            client_b = client_for(cfg_b)
+            self.assertIsNot(client_a1, client_b)
+
+            # 4. Different endpoint → different client.
+            cfg_c = self._config_with_creds("https://c.example", "key-a")
+            client_c = client_for(cfg_c)
+            self.assertIsNot(client_a1, client_c)
+
+            # 5. Pool size kwarg forwarded.
+            cfg_pool = self._config_with_creds(
+                "https://pool.example", "key-pool", pool_maxsize=42,
+            )
+            # Patch the SDK constructor to capture the transport kwarg.
+            with patch(
+                "pypdftotext.azure_docintel_integrator.DocumentIntelligenceClient"
+            ) as mock_client_cls, patch(
+                "pypdftotext.azure_docintel_integrator.RequestsTransport"
+            ) as mock_transport_cls:
+                mock_transport_cls.return_value = MagicMock(name="transport")
+                mock_client_cls.return_value = MagicMock(name="client")
+                client_for(cfg_pool)
+                # RequestsTransport called with pool_maxsize=42.
+                kwargs = mock_transport_cls.call_args.kwargs
+                self.assertEqual(kwargs.get("connection_pool_maxsize"), 42)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_azure_docintel_integrator.py
+++ b/tests/test_azure_docintel_integrator.py
@@ -132,5 +132,90 @@ class TestSubmit(unittest.TestCase):
         )
 
 
+class TestAwaitOne(unittest.TestCase):
+    def setUp(self):
+        with _client_cache_lock:
+            _client_cache.clear()
+        self.cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+            "AZURE_DOCINTEL_TIMEOUT": 30,
+        })
+
+    def _populated_analyze_result(self, num_pages=1):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        return AnalyzeResult({
+            "apiVersion": "2024-11-30",
+            "modelId": "prebuilt-read",
+            "stringIndexType": "textElements",
+            "content": " ".join(f"page{i+1}" for i in range(num_pages)),
+            "pages": [
+                {"pageNumber": i + 1, "angle": 0.0, "width": 8.5, "height": 11.0,
+                 "unit": "inch", "spans": [{"offset": i * 6, "length": 5}],
+                 "words": [], "lines": [], "selectionMarks": []}
+                for i in range(num_pages)
+            ],
+            "styles": [],
+        })
+
+    def test_await_one_success(self):
+        """Happy path: poller returns AnalyzeResult → OCRResult.succeeded."""
+        raw = self._populated_analyze_result(num_pages=2)
+        poller = MagicMock(name="poller")
+        poller.result.return_value = raw
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result = integrator.await_one(poller, pdf_name="x.pdf")
+        self.assertTrue(result.succeeded)
+        self.assertEqual(len(result.pages), 2)
+        self.assertIs(result.raw, raw)
+        self.assertIsNone(result.error)
+
+    def test_await_one_timeout_yields_error_result(self):
+        """REGRESSION: poller.result(timeout) returns None on timeout. Must
+        produce OCRResult(error="OCR timeout: ...") and not crash."""
+        poller = MagicMock(name="poller")
+        poller.result.return_value = None
+        # Provide a polling method so cancel_event.set() doesn't crash.
+        poller._polling_method = MagicMock()
+        poller._polling_method.cancel_event = threading.Event()
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        result = integrator.await_one(poller, pdf_name="x.pdf")
+        self.assertFalse(result.succeeded)
+        self.assertIsNone(result.raw)
+        self.assertEqual(result.pages, [])
+        self.assertIsNotNone(result.error)
+        self.assertTrue(result.error.startswith("OCR timeout"))
+        # The cancel_event should have been set so the daemon poll thread can exit.
+        self.assertTrue(poller._polling_method.cancel_event.is_set())
+
+    def test_await_one_error_paths(self):
+        """Parametrized: HttpResponseError and empty-pages produce OCRResult.error."""
+        from azure.core.exceptions import HttpResponseError
+        integrator = AzureDocIntelIntegrator(self.cfg)
+
+        # 1. Poller raises HttpResponseError.
+        poller_http = MagicMock(name="poller_http")
+        poller_http.result.side_effect = HttpResponseError("server error")
+        poller_http._polling_method = MagicMock()
+        poller_http._polling_method.cancel_event = threading.Event()
+        result_http = integrator.await_one(poller_http, pdf_name="x.pdf")
+        self.assertFalse(result_http.succeeded)
+        self.assertTrue(result_http.error.startswith("OCR failed"))
+        self.assertIn("HttpResponseError", result_http.error)
+
+        # 2. AnalyzeResult with zero pages.
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        empty_result = AnalyzeResult({
+            "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+            "stringIndexType": "textElements", "content": "",
+            "pages": [], "styles": [],
+        })
+        poller_empty = MagicMock(name="poller_empty")
+        poller_empty.result.return_value = empty_result
+        result_empty = integrator.await_one(poller_empty, pdf_name="x.pdf")
+        self.assertFalse(result_empty.succeeded)
+        self.assertEqual(result_empty.error, "OCR failed: empty result (analyzeResult.pages was empty)")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_azure_docintel_integrator.py
+++ b/tests/test_azure_docintel_integrator.py
@@ -77,5 +77,60 @@ class TestClientFor(unittest.TestCase):
                 self.assertEqual(kwargs.get("connection_pool_maxsize"), 42)
 
 
+class TestSubmit(unittest.TestCase):
+    def setUp(self):
+        with _client_cache_lock:
+            _client_cache.clear()
+
+    def test_submit_returns_poller_when_client_available(self):
+        """Happy path: submit returns a poller from the SDK."""
+        cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+        fake_poller = MagicMock(name="poller")
+        fake_client = MagicMock(name="client")
+        fake_client.begin_analyze_document.return_value = fake_poller
+        # Patch the env-var precedence path so config creds take effect.
+        with patch.dict(os.environ, {}, clear=False):
+            for var in ("AZURE_DOCINTEL_ENDPOINT", "AZURE_DOCINTEL_SUBSCRIPTION_KEY"):
+                os.environ.pop(var, None)
+            with patch(
+                "pypdftotext.azure_docintel_integrator.client_for",
+                return_value=fake_client,
+            ):
+                integrator = AzureDocIntelIntegrator(cfg)
+                poller = integrator.submit(b"pdfbytes", [0, 2], pdf_name="x.pdf")
+        self.assertIs(poller, fake_poller)
+        # Verify begin_analyze_document was invoked with the expected pages list
+        # (1-based, comma-joined) and the model from config.
+        kwargs = fake_client.begin_analyze_document.call_args.kwargs
+        self.assertEqual(kwargs["model_id"], cfg.AZURE_DOCINTEL_MODEL)
+        self.assertEqual(kwargs["pages"], "1,3")
+        # polling kwarg should be a CancellablePolling instance.
+        from pypdftotext._cancellable_polling import CancellablePolling
+        self.assertIsInstance(kwargs["polling"], CancellablePolling)
+
+    def test_submit_returns_none_when_no_client(self):
+        """No creds → submit returns None and logs an error."""
+        cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "",
+        })
+        with patch.dict(os.environ, {}, clear=False):
+            for var in ("AZURE_DOCINTEL_ENDPOINT", "AZURE_DOCINTEL_SUBSCRIPTION_KEY"):
+                os.environ.pop(var, None)
+            integrator = AzureDocIntelIntegrator(cfg)
+            with self.assertLogs(
+                "pypdftotext.azure_docintel_integrator", level="ERROR"
+            ) as captured:
+                result = integrator.submit(b"pdf", [0])
+        self.assertIsNone(result)
+        self.assertTrue(
+            any("no client" in line.lower() for line in captured.output),
+            f"expected 'no client' in logs; got {captured.output!r}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_azure_docintel_integrator.py
+++ b/tests/test_azure_docintel_integrator.py
@@ -217,5 +217,51 @@ class TestAwaitOne(unittest.TestCase):
         self.assertEqual(result_empty.error, "OCR failed: empty result (analyzeResult.pages was empty)")
 
 
+class TestDeprecatedSurface(unittest.TestCase):
+    def setUp(self):
+        with _client_cache_lock:
+            _client_cache.clear()
+        self.cfg = PyPdfToTextConfig(overrides={
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+
+    def _run_one_ocr(self, integrator):
+        """Helper: run a fake successful OCR so thread-local is populated."""
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        raw = AnalyzeResult({
+            "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+            "stringIndexType": "textElements", "content": "page1",
+            "pages": [{"pageNumber": 1, "angle": 0.0, "width": 8.5, "height": 11.0,
+                       "unit": "inch", "spans": [{"offset": 0, "length": 5}],
+                       "words": [], "lines": [], "selectionMarks": []}],
+            "styles": [],
+        })
+        poller = MagicMock()
+        poller.result.return_value = raw
+        return integrator.await_one(poller, pdf_name="x.pdf"), raw
+
+    def test_last_result_emits_deprecation_warning(self):
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        _, raw = self._run_one_ocr(integrator)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            value = integrator.last_result
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(caught[0].category, DeprecationWarning)
+        self.assertIs(value, raw)
+
+    def test_last_result_default_when_no_ocr_on_thread(self):
+        """Accessing last_result before any OCR on this thread returns the
+        empty AnalyzeResult sentinel (back-compat with the original init)."""
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        integrator = AzureDocIntelIntegrator(self.cfg)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            value = integrator.last_result
+        self.assertIsInstance(value, AnalyzeResult)
+        self.assertIsNone(value.pages)  # AnalyzeResult({}).pages is None.
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -6,10 +6,13 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-from pypdftotext import PyPdfToTextConfig
+from azure.ai.documentintelligence.models import AnalyzeResult
+
+from pypdftotext import PyPdfToTextConfig, AZURE_READ
 from pypdftotext.batch import PdfExtractBatch
 from pypdftotext.pdf_extract import PdfExtract
 from pypdftotext.azure_docintel_integrator import AzureDocIntelIntegrator
+from pypdftotext.ocr_result import OCRResult
 
 
 class TestPdfExtractBatch(unittest.TestCase):
@@ -120,22 +123,17 @@ class TestPdfExtractBatch(unittest.TestCase):
         for page in result["test"].extracted_pages:
             self.assertEqual(page.source, "embedded")
 
-    @patch.object(AzureDocIntelIntegrator, "ocr_pages")
-    @patch.object(AzureDocIntelIntegrator, "create_client")
-    def test_extract_all_with_mock_azure(self, mock_create_client, mock_ocr_pages):
-        """Test extraction with mocked Azure OCR using real sample data."""
+    def test_extract_all_with_mock_azure(self):
+        """Test extraction with mocked Azure OCR using the submit/await_all path."""
         if not self.all70th_pdf_bytes or not self.all70th_expected_text:
             self.skipTest("Sample data not available")
 
-        # Mock Azure to return real expected text
-        mock_create_client.return_value = True
-        mock_ocr_pages.return_value = ["\n".join(page) for page in self.all70th_expected_text]
-
-        # Use config that triggers OCR
+        # Use config that forces OCR (suppress embedded text, low ratio threshold)
         ocr_config = PyPdfToTextConfig(
             overrides={
                 "MIN_LINES_OCR_TRIGGER": 1000,  # High threshold to force OCR
                 "TRIGGER_OCR_PAGE_RATIO": 0.01,  # Low ratio to trigger easily
+                "SUPPRESS_EMBEDDED_TEXT": True,
                 "DISABLE_PROGRESS_BAR": True,
                 "AZURE_DOCINTEL_ENDPOINT": "https://test.azure.com",
                 "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "test_key",
@@ -144,8 +142,37 @@ class TestPdfExtractBatch(unittest.TestCase):
 
         pdfs = {"all70th": self.all70th_pdf_bytes}
         batch = PdfExtractBatch(pdfs, config=ocr_config)
+        fake_poller = MagicMock(name="poller")
+        expected_pages = ["\n".join(page) for page in self.all70th_expected_text]
 
-        result = batch.extract_all()
+        def fake_await_all(pollers, integrator, timeout, *, config=None):
+            extract = batch.pdf_extracts["all70th"]
+            n_ocr = len(extract.ocr_page_idxs)
+            raw = AnalyzeResult({
+                "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+                "stringIndexType": "textElements",
+                "content": " ".join(f"p{i}" for i in extract.ocr_page_idxs),
+                "pages": [
+                    {"pageNumber": i + 1, "angle": 0.0, "width": 8.5,
+                     "height": 11.0, "unit": "inch",
+                     "spans": [{"offset": pos * 3, "length": 2}],
+                     "words": [], "lines": [], "selectionMarks": []}
+                    for pos, i in enumerate(extract.ocr_page_idxs)
+                ],
+                "styles": [],
+            })
+            return {
+                "all70th": OCRResult(
+                    pdf_name="all70th", config=config or ocr_config,
+                    raw=raw,
+                    pages=expected_pages[:n_ocr],
+                    error=None,
+                )
+            }
+
+        with patch.object(AZURE_READ, "submit", return_value=fake_poller) as mock_submit, \
+             patch("pypdftotext.batch.await_all", side_effect=fake_await_all) as mock_await_all:
+            result = batch.extract_all()
 
         # Should have results
         self.assertIn("all70th", result)
@@ -154,63 +181,81 @@ class TestPdfExtractBatch(unittest.TestCase):
         # Should have extracted pages
         self.assertGreater(len(pdf_extract.extracted_pages), 0)
 
-        # If OCR was triggered, verify it was called
-        if any(page.source == "OCR" for page in pdf_extract.extracted_pages):
-            mock_create_client.assert_called()
-            mock_ocr_pages.assert_called()
+        # OCR was submitted and awaited
+        mock_submit.assert_called()
+        mock_await_all.assert_called()
 
     def test_parallel_ocr_with_multiple_pdfs(self):
-        """Test that parallel OCR works with multiple PDFs."""
+        """Test that batch processes multiple PDFs via the submit/await_all path."""
         if not self.all70th_pdf_bytes or not self.all70th_ocr_result:
             self.skipTest("Sample data not available")
 
-        # Mock the Azure OCR to return quickly
-        with patch.object(AzureDocIntelIntegrator, "ocr_pages") as mock_ocr:
-            with patch.object(AzureDocIntelIntegrator, "create_client") as mock_create:
-                mock_create.return_value = True
-                mock_ocr.return_value = ["Page 1 text", "Page 2 text"]
+        # Use config that will trigger OCR
+        ocr_config = PyPdfToTextConfig(
+            overrides={
+                "MIN_LINES_OCR_TRIGGER": 1000,  # Force OCR
+                "TRIGGER_OCR_PAGE_RATIO": 0.01,
+                "SUPPRESS_EMBEDDED_TEXT": True,
+                "DISABLE_PROGRESS_BAR": True,
+                "AZURE_DOCINTEL_ENDPOINT": "https://test.azure.com",
+                "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "test_key",
+            }
+        )
 
-                # Create batch with multiple PDFs
-                pdfs = {
-                    "pdf1": self.all70th_pdf_bytes,
-                    "pdf2": self.all70th_pdf_bytes,
-                }
+        # Create batch with multiple PDFs
+        pdfs = {
+            "pdf1": self.all70th_pdf_bytes,
+            "pdf2": self.all70th_pdf_bytes,
+        }
 
-                # Use config that will trigger OCR
-                ocr_config = PyPdfToTextConfig(
-                    overrides={
-                        "MIN_LINES_OCR_TRIGGER": 1000,  # Force OCR
-                        "TRIGGER_OCR_PAGE_RATIO": 0.01,
-                        "DISABLE_PROGRESS_BAR": True,
-                        "AZURE_DOCINTEL_ENDPOINT": "https://test.azure.com",
-                        "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "test_key",
-                    }
+        batch = PdfExtractBatch(pdfs, config=ocr_config)
+        fake_poller = MagicMock(name="poller")
+
+        def fake_await_all(pollers, integrator, timeout, *, config=None):
+            results = {}
+            for name in pollers:
+                extract = batch.pdf_extracts[name]
+                raw = AnalyzeResult({
+                    "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+                    "stringIndexType": "textElements",
+                    "content": " ".join(f"p{i}" for i in extract.ocr_page_idxs),
+                    "pages": [
+                        {"pageNumber": i + 1, "angle": 0.0, "width": 8.5,
+                         "height": 11.0, "unit": "inch",
+                         "spans": [{"offset": pos * 3, "length": 2}],
+                         "words": [], "lines": [], "selectionMarks": []}
+                        for pos, i in enumerate(extract.ocr_page_idxs)
+                    ],
+                    "styles": [],
+                })
+                results[name] = OCRResult(
+                    pdf_name=name, config=config or ocr_config,
+                    raw=raw,
+                    pages=["OCR text"] * len(extract.ocr_page_idxs),
+                    error=None,
                 )
+            return results
 
-                batch = PdfExtractBatch(pdfs, config=ocr_config, max_workers=2)
-                result = batch.extract_all()
+        with patch.object(AZURE_READ, "submit", return_value=fake_poller), \
+             patch("pypdftotext.batch.await_all", side_effect=fake_await_all):
+            result = batch.extract_all()
 
-                # Should have results for both PDFs
-                self.assertEqual(len(result), 2)
-                self.assertIn("pdf1", result)
-                self.assertIn("pdf2", result)
+        # Should have results for both PDFs
+        self.assertEqual(len(result), 2)
+        self.assertIn("pdf1", result)
+        self.assertIn("pdf2", result)
 
-    @patch.object(AzureDocIntelIntegrator, "ocr_pages")
-    @patch.object(AzureDocIntelIntegrator, "create_client")
-    def test_ocr_error_handling(self, mock_create_client, mock_ocr_pages):
-        """Test that OCR errors are handled gracefully."""
+    def test_ocr_error_handling(self):
+        """Test that OCR errors are handled gracefully via the await_all path."""
         if not self.deid_epic_pdf_bytes:
             self.skipTest("Sample PDF not available")
-
-        # Mock Azure to raise an error
-        mock_create_client.return_value = True
-        mock_ocr_pages.side_effect = Exception("Azure API Error")
 
         # Use config that triggers OCR
         ocr_config = PyPdfToTextConfig(
             overrides={
                 "MIN_LINES_OCR_TRIGGER": 1000,  # Force OCR
                 "TRIGGER_OCR_PAGE_RATIO": 0.01,
+                "SUPPRESS_EMBEDDED_TEXT": True,
                 "DISABLE_PROGRESS_BAR": True,
                 "AZURE_DOCINTEL_ENDPOINT": "https://test.azure.com",
                 "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "test_key",
@@ -219,15 +264,35 @@ class TestPdfExtractBatch(unittest.TestCase):
 
         pdfs = {"failing_pdf": self.deid_epic_pdf_bytes}
         batch = PdfExtractBatch(pdfs, config=ocr_config)
+        fake_poller = MagicMock(name="poller")
 
-        # Should not raise exception
-        result = batch.extract_all()
+        def fake_await_all(pollers, integrator, timeout, *, config=None):
+            # Simulate Azure API error returned as an OCRResult with error set
+            return {
+                name: OCRResult(
+                    pdf_name=name, config=config or ocr_config,
+                    raw=None, pages=[],
+                    error="OCR failed: Azure API Error",
+                )
+                for name in pollers
+            }
 
-        # Should still return the PdfExtract with embedded text
+        with patch.object(AZURE_READ, "submit", return_value=fake_poller), \
+             patch("pypdftotext.batch.await_all", side_effect=fake_await_all):
+            # Should not raise exception
+            result = batch.extract_all()
+
+        # Should still return the PdfExtract
         self.assertIn("failing_pdf", result)
         self.assertIsInstance(result["failing_pdf"], PdfExtract)
-        # Should have extracted embedded text even though OCR failed
-        self.assertGreater(len(result["failing_pdf"].extracted_pages), 0)
+        # Should have extracted pages (with ocr_error set on OCR pages)
+        pdf_extract = result["failing_pdf"]
+        self.assertGreater(len(pdf_extract.extracted_pages), 0)
+        # All OCR-eligible pages should carry the error
+        for idx in pdf_extract.ocr_page_idxs:
+            self.assertEqual(
+                pdf_extract.extracted_pages[idx].ocr_error, "OCR failed: Azure API Error"
+            )
 
     def test_real_pdf_processing_end_to_end(self):
         """Test complete workflow with real PDFs and no OCR."""
@@ -289,6 +354,125 @@ class TestPdfExtractBatch(unittest.TestCase):
             self.assertEqual(pdf_extract.config.MIN_LINES_OCR_TRIGGER, 5)
             self.assertEqual(pdf_extract.config.TRIGGER_OCR_PAGE_RATIO, 0.8)
             self.assertEqual(pdf_extract.config.MAX_CHARS_PER_PDF_PAGE, 50000)
+
+
+class TestPerformBatchOcrSubmitAndAwait(unittest.TestCase):
+    """Coverage tests for the rewritten _perform_batch_ocr."""
+
+    def setUp(self):
+        from pathlib import Path
+        self.samples_dir = Path("samples")
+        if not (self.samples_dir / "all70th.pdf").exists():
+            self.skipTest("Sample PDF not available")
+        self.pdf_bytes = (self.samples_dir / "all70th.pdf").read_bytes()
+        self.cfg = PyPdfToTextConfig(overrides={
+            "DISABLE_OCR": False,
+            "MIN_LINES_OCR_TRIGGER": 1,
+            "TRIGGER_OCR_PAGE_RATIO": 0.5,
+            "DISABLE_PROGRESS_BAR": True,
+            "MAX_CHARS_PER_PDF_PAGE": 25000,
+            "SUPPRESS_EMBEDDED_TEXT": True,
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+
+    def _make_raw(self, extract):
+        """Build a populated AnalyzeResult for the pages this extract needs."""
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        ocr_idxs = extract.ocr_page_idxs
+        return AnalyzeResult({
+            "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+            "stringIndexType": "textElements",
+            "content": " ".join(f"p{i}" for i in ocr_idxs),
+            "pages": [
+                {"pageNumber": i + 1, "angle": 0.0, "width": 8.5,
+                 "height": 11.0, "unit": "inch",
+                 "spans": [{"offset": pos * 3, "length": 2}],
+                 "words": [], "lines": [], "selectionMarks": []}
+                for pos, i in enumerate(ocr_idxs)
+            ],
+            "styles": [],
+        })
+
+    def test_perform_batch_ocr_uses_azure_read_no_threadpool(self):
+        """Batch dispatches via AZURE_READ.submit + module-level await_all;
+        does NOT instantiate a ThreadPoolExecutor for OCR."""
+        from pypdftotext import AZURE_READ
+        from pypdftotext.batch import PdfExtractBatch
+        from pypdftotext.ocr_result import OCRResult
+        from unittest.mock import patch
+
+        batch = PdfExtractBatch({"a": self.pdf_bytes, "b": self.pdf_bytes}, config=self.cfg)
+        fake_poller = MagicMock(name="poller")
+
+        def fake_await_all(pollers, integrator, timeout, *, config=None):
+            return {
+                name: OCRResult(
+                    pdf_name=name, config=config or self.cfg,
+                    raw=self._make_raw(batch.pdf_extracts[name]),
+                    pages=["OCR_TEXT"] * len(batch.pdf_extracts[name].ocr_page_idxs),
+                    error=None,
+                )
+                for name in pollers
+            }
+
+        with patch.object(AZURE_READ, "submit", return_value=fake_poller) as mock_submit, \
+             patch("pypdftotext.batch.await_all", side_effect=fake_await_all) as mock_await_all, \
+             patch("pypdftotext.batch.ThreadPoolExecutor") as mock_pool:
+            batch.extract_all()
+        # Submit was called once per PDF.
+        self.assertEqual(mock_submit.call_count, 2)
+        # await_all was called once with both pollers.
+        self.assertEqual(mock_await_all.call_count, 1)
+        args, kwargs = mock_await_all.call_args
+        pollers_arg = args[0] if args else kwargs["pollers"]
+        self.assertEqual(set(pollers_arg.keys()), {"a", "b"})
+        # ThreadPoolExecutor must NOT be constructed inside _perform_batch_ocr.
+        self.assertEqual(mock_pool.call_count, 0)
+
+    def test_partial_failure_does_not_crash_batch(self):
+        """One PDF fails OCR (error result); the other succeeds; batch returns both."""
+        from pypdftotext import AZURE_READ
+        from pypdftotext.batch import PdfExtractBatch
+        from pypdftotext.ocr_result import OCRResult
+        from unittest.mock import patch
+
+        batch = PdfExtractBatch({"good": self.pdf_bytes, "bad": self.pdf_bytes}, config=self.cfg)
+        fake_poller = MagicMock(name="poller")
+
+        def fake_await_all(pollers, integrator, timeout, *, config=None):
+            good_extract = batch.pdf_extracts["good"]
+            good_pages = ["OCR_GOOD"] * len(good_extract.ocr_page_idxs)
+            return {
+                "good": OCRResult(
+                    pdf_name="good", config=config or self.cfg,
+                    raw=self._make_raw(good_extract),
+                    pages=good_pages, error=None,
+                ),
+                "bad": OCRResult(
+                    pdf_name="bad", config=config or self.cfg, raw=None,
+                    pages=[], error="OCR timeout: simulated",
+                ),
+            }
+
+        with patch.object(AZURE_READ, "submit", return_value=fake_poller), \
+             patch("pypdftotext.batch.await_all", side_effect=fake_await_all):
+            results = batch.extract_all()
+        # Both PDFs are in the results dict.
+        self.assertIn("good", results)
+        self.assertIn("bad", results)
+        # Good has OCR text populated.
+        good_extract = results["good"]
+        for idx in good_extract.ocr_page_idxs:
+            self.assertEqual(good_extract.extracted_pages[idx].text, "OCR_GOOD")
+            self.assertIsNone(good_extract.extracted_pages[idx].ocr_error)
+        # Bad has ocr_error set on all OCR pages.
+        bad_extract = results["bad"]
+        for idx in bad_extract.ocr_page_idxs:
+            self.assertEqual(
+                bad_extract.extracted_pages[idx].ocr_error, "OCR timeout: simulated",
+            )
+            self.assertEqual(bad_extract.extracted_pages[idx].text, "")
 
 
 if __name__ == "__main__":

--- a/tests/test_cancellable_polling.py
+++ b/tests/test_cancellable_polling.py
@@ -1,0 +1,53 @@
+"""SDK canary test: CancellablePolling depends on private LROBasePolling internals.
+
+If azure-core refactors `_delay`, `_extract_delay`, or `finished` in
+LROBasePolling, the construction or behavior here will fail loudly — that's
+the point. CI failure here means: go read the azure-core changelog.
+"""
+
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from pypdftotext._cancellable_polling import CancellablePolling
+
+
+class TestCancellablePolling(unittest.TestCase):
+    def _make_polling(self, lro_delay=0.05):
+        """Construct a CancellablePolling with a short polling interval.
+
+        We bypass `initialize()` (which needs a full pipeline response) by
+        injecting the attributes `_delay` reads directly. This keeps the test
+        focused on the cancel-event semantics rather than the SDK plumbing.
+        """
+        polling = CancellablePolling(lro_delay)
+        # Minimal scaffolding so _extract_delay/_extract_delay don't crash.
+        polling._timeout = lro_delay
+        polling._pipeline_response = MagicMock()
+        polling._pipeline_response.http_response.headers = {}
+        return polling
+
+    def test_cancel_event_terminates_polling(self):
+        """cancel_event.set() makes _delay return immediately AND finished()
+        return True."""
+        polling = self._make_polling(lro_delay=10.0)  # Would normally sleep 10s
+        # finished() should be False before cancel is set (super().finished()
+        # raises without an _operation; we override that).
+        self.assertFalse(polling.cancel_event.is_set())
+
+        # Cancel from a sidecar thread; main thread blocks in _delay.
+        def cancel_after():
+            time.sleep(0.05)
+            polling.cancel_event.set()
+        threading.Thread(target=cancel_after, daemon=True).start()
+
+        start = time.monotonic()
+        polling._delay()
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 0.5, "expected _delay to return within 500ms after cancel")
+        self.assertTrue(polling.finished())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -159,3 +159,17 @@ class TestDictConfigShorthand:
         )
         assert isinstance(batch.config, PyPdfToTextConfig)
         assert batch.config.DISABLE_OCR is True
+
+
+def test_azure_client_pool_maxsize_default():
+    """AZURE_CLIENT_POOL_MAXSIZE defaults to 20."""
+    from pypdftotext import PyPdfToTextConfig
+    config = PyPdfToTextConfig()
+    assert config.AZURE_CLIENT_POOL_MAXSIZE == 20
+
+
+def test_azure_client_pool_maxsize_override():
+    """AZURE_CLIENT_POOL_MAXSIZE can be set via overrides."""
+    from pypdftotext import PyPdfToTextConfig
+    config = PyPdfToTextConfig(overrides={"AZURE_CLIENT_POOL_MAXSIZE": 50})
+    assert config.AZURE_CLIENT_POOL_MAXSIZE == 50

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -833,5 +833,95 @@ class TestExtractedPageOcrError(unittest.TestCase):
         self.assertEqual(page.ocr_error, "OCR timeout: simulated")
 
 
+class TestOCRResult(unittest.TestCase):
+    def _fake_analyze_result_dict(self, num_pages=2):
+        """Build a minimal dict suitable for AnalyzeResult.__init__."""
+        return {
+            "apiVersion": "2024-11-30",
+            "modelId": "prebuilt-read",
+            "stringIndexType": "textElements",
+            "content": "page1 text\npage2 text",
+            "pages": [
+                {"pageNumber": i + 1, "angle": 0.0, "width": 8.5, "height": 11.0,
+                 "unit": "inch", "spans": [{"offset": i * 11, "length": 10}],
+                 "words": [], "lines": [], "selectionMarks": []}
+                for i in range(num_pages)
+            ],
+            "styles": [],
+        }
+
+    def test_succeeded_true_when_raw_has_pages_and_no_error(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        raw = AnalyzeResult(self._fake_analyze_result_dict(num_pages=1))
+        result = OCRResult(
+            pdf_name="x.pdf",
+            config=PyPdfToTextConfig(),
+            raw=raw,
+            pages=["page1 text"],
+        )
+        self.assertTrue(result.succeeded)
+        self.assertIsNone(result.error)
+
+    def test_succeeded_false_when_error_set(self):
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        result = OCRResult(
+            pdf_name="x.pdf",
+            config=PyPdfToTextConfig(),
+            raw=None,
+            pages=[],
+            error="OCR timeout: simulated",
+        )
+        self.assertFalse(result.succeeded)
+
+    def test_succeeded_false_when_raw_none(self):
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        result = OCRResult(pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=None, pages=[])
+        self.assertFalse(result.succeeded)
+
+    def test_page_at_index_returns_page_when_present(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        raw = AnalyzeResult(self._fake_analyze_result_dict(num_pages=2))
+        result = OCRResult(
+            pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=raw, pages=["a", "b"],
+        )
+        page = result.page_at_index(0)
+        self.assertIsNotNone(page)
+        self.assertEqual(page.page_number, 1)
+        page2 = result.page_at_index(1)
+        self.assertEqual(page2.page_number, 2)
+
+    def test_page_at_index_returns_none_when_missing(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        raw = AnalyzeResult(self._fake_analyze_result_dict(num_pages=1))
+        result = OCRResult(
+            pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=raw, pages=["a"],
+        )
+        self.assertIsNone(result.page_at_index(99))
+
+    def test_rotation_degrees_zero_when_page_missing(self):
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        result = OCRResult(pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=None, pages=[])
+        self.assertEqual(result.rotation_degrees(0), 0.0)
+
+    def test_handwritten_ratio_zero_when_no_styles(self):
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        from pypdftotext import PyPdfToTextConfig
+        from pypdftotext.ocr_result import OCRResult
+        raw = AnalyzeResult(self._fake_analyze_result_dict(num_pages=1))
+        result = OCRResult(
+            pdf_name="x.pdf", config=PyPdfToTextConfig(), raw=raw, pages=["a"],
+        )
+        self.assertEqual(result.handwritten_ratio(0), 0.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -814,5 +814,24 @@ class TestPdfExtract(unittest.TestCase):
         self.assertEqual(len(pdf.extracted_pages), original_count - 1)
 
 
+class TestExtractedPageOcrError(unittest.TestCase):
+    def test_ocr_error_defaults_to_none(self):
+        """ExtractedPage.ocr_error is None by default."""
+        from unittest.mock import MagicMock
+        from pypdftotext.extracted_page import ExtractedPage
+        # Use any page from any sample PDF; we don't need OCR to test the field.
+        # Construct a minimal mock PageObject via MagicMock.
+        page = ExtractedPage(page_obj=MagicMock(), handwritten_ratio=0.0, text="hello")
+        self.assertIsNone(page.ocr_error)
+
+    def test_ocr_error_can_be_set(self):
+        """ExtractedPage.ocr_error accepts string assignment."""
+        from unittest.mock import MagicMock
+        from pypdftotext.extracted_page import ExtractedPage
+        page = ExtractedPage(page_obj=MagicMock(), handwritten_ratio=0.0, text="")
+        page.ocr_error = "OCR timeout: simulated"
+        self.assertEqual(page.ocr_error, "OCR timeout: simulated")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -348,10 +348,8 @@ class TestPdfExtract(unittest.TestCase):
             azure_integrator = AzureDocIntelIntegrator(config=config)
             azure_integrator.client = mock_client
 
-            # Patch the PdfExtract to use our configured integrator
-            with patch("pypdftotext.pdf_extract.AzureDocIntelIntegrator") as MockAzureClass:
-                MockAzureClass.return_value = azure_integrator
-
+            # Patch AZURE_READ so _extract_pages uses our configured integrator
+            with patch("pypdftotext.pdf_extract.AZURE_READ", azure_integrator):
                 # Create PdfExtract which will use our mocked client
                 pdf = PdfExtract(self.all70th_pdf, config=config)
 
@@ -461,10 +459,8 @@ class TestPdfExtract(unittest.TestCase):
             azure_integrator = AzureDocIntelIntegrator(config=config)
             azure_integrator.client = mock_client
 
-            # Patch the PdfExtract to use our configured integrator
-            with patch("pypdftotext.pdf_extract.AzureDocIntelIntegrator") as MockAzureClass:
-                MockAzureClass.return_value = azure_integrator
-
+            # Patch AZURE_READ so _extract_pages uses our configured integrator
+            with patch("pypdftotext.pdf_extract.AZURE_READ", azure_integrator):
                 # Create PdfExtract
                 pdf = PdfExtract(self.all70th_pdf, config=config)
 
@@ -929,6 +925,121 @@ class TestOCRResult(unittest.TestCase):
         from pypdftotext.ocr_result import OCRResult as _Direct
         self.assertIs(pypdftotext.OCRResult, _Direct)
         self.assertIn("OCRResult", pypdftotext.__all__)
+
+
+class TestOcrEndToEnd(unittest.TestCase):
+    """Coverage-based: success, timeout, azure-error variants of PdfExtract.ocr."""
+
+    def setUp(self):
+        from pathlib import Path
+        self.samples_dir = Path("samples")
+        self.pdf_path = self.samples_dir / "all70th.pdf"
+        if not self.pdf_path.exists():
+            self.skipTest("Sample PDF not available")
+        self.cfg = PyPdfToTextConfig(overrides={
+            "DISABLE_OCR": False,
+            "MIN_LINES_OCR_TRIGGER": 1,
+            "TRIGGER_OCR_PAGE_RATIO": 0.5,
+            "DISABLE_PROGRESS_BAR": True,
+            "MAX_CHARS_PER_PDF_PAGE": 25000,
+            "AZURE_DOCINTEL_ENDPOINT": "https://x.example",
+            "AZURE_DOCINTEL_SUBSCRIPTION_KEY": "key",
+        })
+
+    def _build_success_ocr_result(self, extract):
+        """Build a synthetic successful OCRResult for the pages extract needs."""
+        from pypdftotext.ocr_result import OCRResult
+        from azure.ai.documentintelligence.models import AnalyzeResult
+        ocr_idxs = extract.ocr_page_idxs
+        raw = AnalyzeResult({
+            "apiVersion": "2024-11-30", "modelId": "prebuilt-read",
+            "stringIndexType": "textElements",
+            "content": " ".join(f"page{i}" for i in ocr_idxs),
+            "pages": [
+                {"pageNumber": i + 1, "angle": 0.0, "width": 8.5,
+                 "height": 11.0, "unit": "inch",
+                 "spans": [{"offset": idx_pos * 6, "length": 5}],
+                 "words": [], "lines": [], "selectionMarks": []}
+                for idx_pos, i in enumerate(ocr_idxs)
+            ],
+            "styles": [],
+        })
+        pages = [f"OCR_PAGE_{i}" for i in ocr_idxs]
+        return OCRResult(
+            pdf_name=extract.pdf_name, config=extract.config,
+            raw=raw, pages=pages,
+        )
+
+    def test_ocr_end_to_end_success(self):
+        """Mocked azure produces a successful OCRResult; ExtractedPages reflect it."""
+        from pypdftotext.pdf_extract import PdfExtract
+        from unittest.mock import patch, MagicMock
+        # Force OCR by suppressing embedded text on every page.
+        cfg = PyPdfToTextConfig(base=self.cfg, overrides={"SUPPRESS_EMBEDDED_TEXT": True})
+        extract = PdfExtract(self.pdf_path.read_bytes(), config=cfg, pdf_name="t.pdf")
+        # Trigger _extract_pages so ocr_page_idxs is populated, but don't run ocr() yet.
+        extract._extracted_pages = None
+        mock_azure = MagicMock(name="mock_azure")
+        mock_azure.submit.return_value = MagicMock(name="poller")
+        mock_azure.await_one.side_effect = lambda p, **kw: self._build_success_ocr_result(extract)
+        with patch("pypdftotext.pdf_extract.AZURE_READ", mock_azure):
+            _ = extract.extracted_pages
+        self.assertIsNotNone(extract.ocr_result)
+        self.assertTrue(extract.ocr_result.succeeded)
+        # Every page that was OCR'd has source="OCR" and non-empty text.
+        for idx in extract.ocr_page_idxs:
+            self.assertEqual(extract.extracted_pages[idx].source, "OCR")
+            self.assertTrue(extract.extracted_pages[idx].text.startswith("OCR_PAGE_"))
+            self.assertIsNone(extract.extracted_pages[idx].ocr_error)
+
+    def test_ocr_end_to_end_failure_sets_ocr_error(self):
+        """Mocked azure returns OCRResult with error; ExtractedPages get ocr_error."""
+        from pypdftotext.pdf_extract import PdfExtract
+        from pypdftotext.ocr_result import OCRResult
+        from unittest.mock import patch, MagicMock
+        cfg = PyPdfToTextConfig(base=self.cfg, overrides={"SUPPRESS_EMBEDDED_TEXT": True})
+        extract = PdfExtract(self.pdf_path.read_bytes(), config=cfg, pdf_name="t.pdf")
+        extract._extracted_pages = None
+        failure = OCRResult(
+            pdf_name="t.pdf", config=cfg, raw=None, pages=[],
+            error="OCR timeout: simulated for test",
+        )
+        mock_azure = MagicMock(name="mock_azure")
+        mock_azure.submit.return_value = MagicMock(name="poller")
+        mock_azure.await_one.return_value = failure
+        with patch("pypdftotext.pdf_extract.AZURE_READ", mock_azure):
+            _ = extract.extracted_pages
+        self.assertIsNotNone(extract.ocr_result)
+        self.assertFalse(extract.ocr_result.succeeded)
+        for idx in extract.ocr_page_idxs:
+            self.assertEqual(
+                extract.extracted_pages[idx].ocr_error, "OCR timeout: simulated for test",
+            )
+            self.assertEqual(extract.extracted_pages[idx].text, "")
+            self.assertEqual(extract.extracted_pages[idx].source, "embedded")
+
+    def test_ocr_logs_no_false_success_on_failure(self):
+        """The misleading 'OCR'd successfully' log must not fire on failure."""
+        from pypdftotext.pdf_extract import PdfExtract
+        from pypdftotext.ocr_result import OCRResult
+        from unittest.mock import patch, MagicMock
+        cfg = PyPdfToTextConfig(base=self.cfg, overrides={"SUPPRESS_EMBEDDED_TEXT": True})
+        extract = PdfExtract(self.pdf_path.read_bytes(), config=cfg, pdf_name="t.pdf")
+        extract._extracted_pages = None
+        failure = OCRResult(
+            pdf_name="t.pdf", config=cfg, raw=None, pages=[],
+            error="OCR failed: HttpResponseError: simulated",
+        )
+        mock_azure = MagicMock(name="mock_azure")
+        mock_azure.submit.return_value = MagicMock(name="poller")
+        mock_azure.await_one.return_value = failure
+        with patch("pypdftotext.pdf_extract.AZURE_READ", mock_azure):
+            with self.assertLogs("pypdftotext", level="INFO") as captured:
+                # Trigger the OCR path.
+                _ = extract.extracted_pages
+        # Assert no "successfully" log emitted at INFO.
+        success_lines = [line for line in captured.output if "successfully" in line.lower()]
+        self.assertEqual(success_lines, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -922,6 +922,14 @@ class TestOCRResult(unittest.TestCase):
         )
         self.assertEqual(result.handwritten_ratio(0), 0.0)
 
+    def test_ocr_result_publicly_importable(self):
+        """OCRResult is importable from the top-level package."""
+        import pypdftotext
+        self.assertTrue(hasattr(pypdftotext, "OCRResult"))
+        from pypdftotext.ocr_result import OCRResult as _Direct
+        self.assertIs(pypdftotext.OCRResult, _Direct)
+        self.assertIn("OCRResult", pypdftotext.__all__)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Fixes the silent-`None` timeout bug in `AzureDocIntelIntegrator.ocr_pages` and the misleading "OCR'd successfully" log that fired regardless of result validity.
- Eliminates cross-thread contamination (pattern P4) by replacing session-scoped `last_result` with per-call `OCRResult` value objects.
- Restructures the batch path from N-worker-thread-per-PDF to submit-all-then-collective-await, halving thread count for `PdfExtractBatch` and consolidating the underlying `DocumentIntelligenceClient` behind a credential-keyed cache.
- Adds cooperative cancellation via `CancellablePolling` so timed-out OCR ops don't leak daemon threads.

Public API delta is additive only: `OCRResult`, `PdfExtract.ocr_result`, `ExtractedPage.ocr_error`, `PyPdfToTextConfig.AZURE_CLIENT_POOL_MAXSIZE`. All previously-public surfaces (`AZURE_READ.last_result`, integrator helper methods) continue to work via thread-local-backed deprecation wrappers.

Full design spec: `docs/superpowers/specs/2026-05-13-ocr-submit-and-await-design.md`
Full implementation plan: `docs/superpowers/plans/2026-05-13-ocr-submit-and-await.md`

## Test plan
- [x] 110/110 unit tests pass (`pytest tests/ -v`)
- [x] 8/8 doctests pass (`pytest --doctest-modules pypdftotext/`)
- [x] `ruff check pypdftotext/` clean
- [x] `ruff format --check pypdftotext/` clean
- [x] `pyright pypdftotext/` 0 errors / 0 warnings
- [x] Regression test for the original timeout bug: `tests/test_azure_docintel_integrator.py::TestAwaitOne::test_await_one_timeout_yields_error_result`
- [x] P4 contamination regression test: `tests/test_azure_docintel_integrator.py::TestThreadLocalIsolation::test_thread_local_isolation_across_threads`
- [x] Batch no-ThreadPool invariant: `tests/test_batch.py::TestPerformBatchOcrSubmitAndAwait::test_perform_batch_ocr_uses_azure_read_no_threadpool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
